### PR TITLE
Migration to net4.8

### DIFF
--- a/README-UBUNTU.md
+++ b/README-UBUNTU.md
@@ -6,7 +6,7 @@
 
 - ROS2 installed on the system, along with `test-msgs`, `cyclonedds` and `fastrtps` packages
 - vcstool package - [see here](https://github.com/dirk-thomas/vcstool)
-- .NET core 3.1 sdk - [see here](https://www.microsoft.com/net/learn/get-started)
+- .NET core 5.0 sdk - [see here](https://www.microsoft.com/net/learn/get-started)
 
 The following script can be used to install the aforementioned prerequisites on Ubuntu 20.04:
 
@@ -28,7 +28,7 @@ rm packages-microsoft-prod.deb
 sudo apt-get update; \
   sudo apt-get install -y apt-transport-https && \
   sudo apt-get update && \
-  sudo apt-get install -y dotnet-sdk-3.1
+  sudo apt-get install -y dotnet-sdk-5.0
 ```
 
 ### Steps

--- a/src/ros2cs/ros2cs_common/CMakeLists.txt
+++ b/src/ros2cs/ros2cs_common/CMakeLists.txt
@@ -20,7 +20,6 @@ find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_export_assemblies REQUIRED)
 find_package(dotnet_cmake_module REQUIRED)
 
-set(CSHARP_TARGET_FRAMEWORK "netcoreapp3.1")
 find_package(DotNETExtra REQUIRED)
 
 set(CS_INTERFACES

--- a/src/ros2cs/ros2cs_core/CMakeLists.txt
+++ b/src/ros2cs/ros2cs_core/CMakeLists.txt
@@ -29,7 +29,6 @@ find_package(ament_cmake_export_assemblies REQUIRED)
 find_package(ament_cmake REQUIRED)
 find_package(dotnet_cmake_module REQUIRED)
 
-set(CSHARP_TARGET_FRAMEWORK "netcoreapp3.1")
 find_package(DotNETExtra REQUIRED)
 
 # Used by ros2cs_native

--- a/src/ros2cs/ros2cs_examples/CMakeLists.txt
+++ b/src/ros2cs/ros2cs_examples/CMakeLists.txt
@@ -25,7 +25,6 @@ find_package(builtin_interfaces REQUIRED)
 find_package(dotnet_cmake_module REQUIRED)
 find_package(rosidl_generator_cs REQUIRED)
 
-set(CSHARP_TARGET_FRAMEWORK "netcoreapp3.1")
 find_package(DotNETExtra REQUIRED)
 
 set(_assemblies_dep_dlls

--- a/src/ros2cs/ros2cs_tests/CMakeLists.txt
+++ b/src/ros2cs/ros2cs_tests/CMakeLists.txt
@@ -6,7 +6,6 @@ if(BUILD_TESTING)
   find_package(ament_cmake REQUIRED)
   find_package(dotnet_cmake_module REQUIRED)
 
-  set(CSHARP_TARGET_FRAMEWORK "netcoreapp3.1")
   find_package(DotNETExtra REQUIRED)
 
   find_package(std_msgs REQUIRED)


### PR DESCRIPTION
This cleans up the hard coded `netcoreapp3.1` directives and leaves setting up dotnet version for `dotnet_cmake_module`.