### PR TITLE
Remove lower bound check of timeoutSec in SpinOnce

### DIFF
--- a/src/ros2cs/ros2cs_core/Ros2cs.cs
+++ b/src/ros2cs/ros2cs_core/Ros2cs.cs
@@ -201,17 +201,6 @@ namespace ROS2
           return;
         }
 
-        if (timeoutSec < 0.0001d)
-        {
-          timeoutSec = 0.0001d;
-
-          if (!warned_once)
-          {
-            Ros2csLogger.GetInstance().LogWarning("Spin timeout too low. Changed to a minimum value of " + timeoutSec.ToString());
-            warned_once = true;
-          }
-        }
-
         // TODO - This can be optimized so that we cache the list and invalidate only with changes
         var allSubscriptions = new List<ISubscriptionBase>();
         foreach (INode node_interface in nodes)


### PR DESCRIPTION
We are running a high-frequency application (around 1000Hz), and allowing zero timeout, making the spinOnce non-blocking, increased performace by a large amount.

Passing 0 or even negative numbers to the final rcl_wait is well defined and there is no reason to impose any limitation in this wrapper code, that I know of.

See: https://docs.ros2.org/beta1/api/rcl/wait_8h.html#a732278988c802fe2c9d8ec24752f9dd9 

_The unit of timeout is nanoseconds. If the timeout is negative then this function will block indefinitely until something in the wait set is valid or it is interrupted. If the timeout is 0 then this function will be non-blocking; checking what's ready now, but not waiting if nothing is ready yet. If the timeout is greater than 0 then this function will return after that period of time has elapsed or the wait set becomes ready, which ever comes first._ 