### PR TITLE
set ros2cs_tests CSHARP_TARGET_FRAMEWORK

### DIFF
--- a/README-UBUNTU.md
+++ b/README-UBUNTU.md
@@ -8,6 +8,7 @@
 
 - ROS2 installed on the system, along with `test-msgs`, `cyclonedds` and `fastrtps` packages
 - vcstool package - [see here](https://github.com/dirk-thomas/vcstool)
+- .NET core 6.0 sdk - [see here](https://www.microsoft.com/net/learn/get-started)
 
 
 ```bash
@@ -25,26 +26,12 @@ sudo apt-get install -y python3-vcstool
 wget https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
 sudo dpkg -i packages-microsoft-prod.deb
 rm packages-microsoft-prod.deb
-```
 
-**Ubuntu 20.04 only**
-
-- .NET core 3.1 sdk - [see here](https://www.microsoft.com/net/learn/get-started)
-
-```
+# install .NET core 6.0 SDK
 sudo apt-get update; \
   sudo apt-get install -y apt-transport-https && \
   sudo apt-get update && \
-  sudo apt-get install -y dotnet-sdk-3.1
-```
-
-**Ubuntu 22.04 only**
-
-- mono - [see here](https://www.mono-project.com/)
-
-```
-sudo apt-get update; \
-  sudo apt install mono-complete
+  sudo apt-get install -y dotnet-sdk-6.0
 ```
 
 **Optional**

--- a/README-WINDOWS.md
+++ b/README-WINDOWS.md
@@ -6,7 +6,7 @@
 
 *  ROS2 installed on the system (additionally you should go to [Building ROS2 section](https://docs.ros.org/en/foxy/Installation/Windows-Development-Setup.html) and check if all `pip` [Install dependencies](https://docs.ros.org/en/foxy/Installation/Windows-Development-Setup.html#install-dependencies) and [Developer tools](https://docs.ros.org/en/foxy/Installation/Windows-Development-Setup.html#install-developer-tools) are installed)
 *  vcstool package - [see here](https://github.com/dirk-thomas/vcstool)
-*  .NET 3.1 sdk - [see here](https://dotnet.microsoft.com/download/dotnet/3.1)
+*  .NET 6.0 sdk - [see here](https://dotnet.microsoft.com/download/dotnet/6.0)
 *  For tests only: xUnit testing framework - [see here](https://xunit.net/)
 
 ### Important notices

--- a/src/ros2cs/ros2cs_tests/CMakeLists.txt
+++ b/src/ros2cs/ros2cs_tests/CMakeLists.txt
@@ -6,6 +6,8 @@ if(BUILD_TESTING)
   find_package(ament_cmake REQUIRED)
   find_package(dotnet_cmake_module REQUIRED)
 
+  set(CSHARP_TARGET_FRAMEWORK "netcoreapp6.0")
+
   if(UNIX)
     find_program(LSB_RELEASE_EXEC lsb_release)
     execute_process(COMMAND ${LSB_RELEASE_EXEC} -rs


### PR DESCRIPTION
This PR fixes Issue #39 and a part of Issue #43 by setting `CSHARP_TARGET_FRAMEWORK` for `ros2cs_tests` to `netcoreapp6.0` to prevent using the new fallback.
It also updates the installation READMEs.