### PR TITLE
Fix regex to match the multi-digital standalone library versions

### DIFF
--- a/src/ros2cs/ros2cs_core/CMakeLists.txt
+++ b/src/ros2cs/ros2cs_core/CMakeLists.txt
@@ -296,7 +296,7 @@ if(STANDALONE_BUILD)
 
   macro(install_standalone_dependencies)
     # Filter valid libraries
-    list(FILTER REQ_STANDALONE_LIBS INCLUDE REGEX ".*(lib|dll|so)(\.[0-9])*$")
+    list(FILTER REQ_STANDALONE_LIBS INCLUDE REGEX ".*(lib|dll|so)(\.[0-9]+)*$")
     list(REMOVE_DUPLICATES REQ_STANDALONE_LIBS)
 
     if(WIN32)


### PR DESCRIPTION
The newest ROS2 release comes with `ddsc` version update from `0.9.1` to `0.10.3`. The current regex for validating standalone libraries can't handle multi-digital versions. This PR fixes it.