### PR TITLE
Modified code generation from read-only to editable

### DIFF
--- a/src/ros2cs/rosidl_generator_cs/resource/msg.cs.em
+++ b/src/ros2cs/rosidl_generator_cs/resource/msg.cs.em
@@ -81,7 +81,7 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
 @[  elif isinstance(member.type, AbstractSequence) and isinstance(member.type.value_type, AbstractNestableType)]@
   public @(get_dotnet_type(member.type)) @(get_field_name(member.type, member.name, message_class)) { get; set; }
 @[  elif isinstance(member.type, Array) and isinstance(member.type.value_type, AbstractNestableType)]@
-  public @(get_dotnet_type(member.type)) @(get_field_name(member.type, member.name, message_class)) { get; private set; }
+  public @(get_dotnet_type(member.type)) @(get_field_name(member.type, member.name, message_class)) { get; set; }
 @[  end if]@
 @[end for]@
 

--- a/src/ros2cs/rosidl_generator_cs/resource/srv.cs.em
+++ b/src/ros2cs/rosidl_generator_cs/resource/srv.cs.em
@@ -84,7 +84,7 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
 @[  elif isinstance(member.type, AbstractSequence) and isinstance(member.type.value_type, AbstractNestableType)]@
   public @(get_dotnet_type(member.type)) @(get_field_name(member.type, member.name, message_class)) { get; set; }
 @[  elif isinstance(member.type, Array) and isinstance(member.type.value_type, AbstractNestableType)]@
-  public @(get_dotnet_type(member.type)) @(get_field_name(member.type, member.name, message_class)) { get; private set; }
+  public @(get_dotnet_type(member.type)) @(get_field_name(member.type, member.name, message_class)) { get; set; }
 @[  end if]@
 @[end for]@
 


### PR DESCRIPTION
I discovered that when modifying values in the ROS2 standard message camera_info, some of the data fields were generated as non-editable. I have updated the code to allow modifications to those fields.

Thank you.