### PR TITLE
Supporting Jazzy distribution

### DIFF
--- a/ros2_jazzy.repos
+++ b/ros2_jazzy.repos
@@ -1,0 +1,41 @@
+repositories:
+  ros2/rosidl_defaults:
+    type: git
+    url: https://github.com/ros2/rosidl_defaults.git
+    version: jazzy
+  ros2/rosidl_core:
+    type: git
+    url: https://github.com/ros2/rosidl_core.git
+    version: jazzy
+  ros2/common_interfaces:
+    type: git
+    url: https://github.com/ros2/common_interfaces.git
+    version: jazzy
+  ros2/example_interfaces:
+    type: git
+    url: https://github.com/ros2/example_interfaces.git
+    version: jazzy
+  ros2/unique_identifier_msgs:
+    type: git
+    url: https://github.com/ros2/unique_identifier_msgs.git
+    version: jazzy
+  ros2/rcl_interfaces:
+    type: git
+    url: https://github.com/ros2/rcl_interfaces.git
+    version: jazzy
+  ros2/geometry2:
+    type: git
+    url: https://github.com/ros2/geometry2.git
+    version: jazzy
+  ros2/test_interface_files:
+    type: git
+    url: https://github.com/ros2/test_interface_files.git
+    version: jazzy
+  external/build_tools/dotnet_cmake_module:
+    type: git
+    url: https://github.com/RobotecAI/dotnet_cmake_module
+    version: 1.1.0
+  external/build_tools/ament_cmake_export_assemblies:
+    type: git
+    url: https://github.com/RobotecAI/ament_cmake_export_assemblies
+    version: master

--- a/src/ros2cs/ros2cs_core/CMakeLists.txt
+++ b/src/ros2cs/ros2cs_core/CMakeLists.txt
@@ -377,7 +377,7 @@ if(STANDALONE_BUILD)
     rosidl_typesupport_introspection_cpp
     spdlog
     tracetools
-    yaml
+    yaml-cpp
     tinyxml2
   )
   

--- a/src/ros2cs/ros2cs_core/CMakeLists.txt
+++ b/src/ros2cs/ros2cs_core/CMakeLists.txt
@@ -238,7 +238,7 @@ if(STANDALONE_BUILD)
       endif()
 
       # Get rmw_cyclonedds_cpp for humble
-      if("${_library_name}" STREQUAL "rmw_cyclonedds_cpp" AND (ros2_distro STREQUAL "humble" OR ros2_distro STREQUAL "rolling"))
+      if("${_library_name}" STREQUAL "rmw_cyclonedds_cpp" AND (ros2_distro STREQUAL "humble" OR ros2_distro STREQUAL "jazzy" OR ros2_distro STREQUAL "rolling"))
         fetch_target_lib(rmw_cyclonedds_cpp::rmw_cyclonedds_cpp)
         list(APPEND REQ_STANDALONE_LIBS ${rmw_cyclonedds_cpp_rmw_cyclonedds_cpp_LIB_PATH})
       endif()

--- a/src/ros2cs/rosidl_generator_cs/cmake/rosidl_generator_cs_generate_interfaces.cmake
+++ b/src/ros2cs/rosidl_generator_cs/cmake/rosidl_generator_cs_generate_interfaces.cmake
@@ -245,7 +245,7 @@ foreach(_generated_msg_c_ts_file ${_generated_msg_c_ts_files})
 
   set(ros2_distro "$ENV{ROS_DISTRO}")
 
-  if(ros2_distro STREQUAL "humble" OR ros2_distro STREQUAL "rolling")
+  if(${rosidl_cmake_VERSION} VERSION_GREATER 2.5.0)
     rosidl_get_typesupport_target(c_typesupport_target "${PROJECT_NAME}" "rosidl_typesupport_c")
     target_link_libraries(${_target_name} "${c_typesupport_target}")
   else()
@@ -352,7 +352,7 @@ foreach(_generated_srv_c_ts_file ${_generated_srv_c_ts_files})
 
   set(ros2_distro "$ENV{ROS_DISTRO}")
 
-  if(ros2_distro STREQUAL "humble" OR ros2_distro STREQUAL "rolling")
+  if(${rosidl_cmake_VERSION} VERSION_GREATER 2.5.0)
     rosidl_get_typesupport_target(c_typesupport_target "${PROJECT_NAME}" "rosidl_typesupport_c")
     target_link_libraries(${_target_name} "${c_typesupport_target}")
   else()


### PR DESCRIPTION
In this PR, I will introduce a support for Jazzy distribution. (Iron is not tested but I think it will work)

There are some changes:

- Add repository information for Jazzy, including new package `rosidl_core`.
  - `rosidl_core` is newly introduced package in https://github.com/ros2/rosidl_defaults/pull/22
- Changes for CMake functions
  - Use more proper way (checking dependencies version) to use `rosidl_get_typesupport_target`
  - Add jazzy as CycloneDDS supported distribution.

I tested this PR on my Ubuntu 24.04 + Unity 2022.3.15f1 + ROS 2 Jazzy environment.