### PR TITLE
Fix ros2cs phase 15 review findings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,5 @@
 *.jpg filter=lfs diff=lfs merge=lfs -text
 *.tga filter=lfs diff=lfs merge=lfs -text
 *.zip filter=lfs diff=lfs merge=lfs -text
+*.sh text eol=lf
+*.ps1 text eol=crlf

--- a/README-UBUNTU.md
+++ b/README-UBUNTU.md
@@ -1,5 +1,24 @@
 # ROS2CS - Ubuntu 20.04 and Ubuntu 22.04
 
+> Modifications Copyright (c) 2026 Jianbin Liu.
+>
+> Modifications by Jianbin Liu:
+> - Marked Ubuntu instructions as legacy / not recently verified for the current Jazzy maintenance branch.
+> - Noted the .NET 8 tests/examples target framework change without rewriting the Ubuntu flow.
+
+## Current verification status
+
+These Ubuntu instructions are legacy guidance. They have not been recently verified for the current Jazzy maintenance branch.
+
+Current local validation was performed on Windows 10 LTSC with ROS 2 Jazzy. Ubuntu 20.04 / 22.04 / 24.04 should be treated as unverified until a fresh Ubuntu build/test run records commands, exit codes, and key output.
+
+The current target framework split is:
+
+- `ros2cs_common`, `ros2cs_core`, and generated message assemblies: `netstandard2.0`.
+- `ros2cs_tests` and `ros2cs_examples`: `net8.0`.
+
+The older `.NET 6.0` references below are retained as historical setup context and need refresh before claiming Ubuntu support for this branch.
+
 ## Building
 
 ### Prerequisites

--- a/README-UBUNTU.md
+++ b/README-UBUNTU.md
@@ -1,10 +1,11 @@
-# ROS2CS - Ubuntu 20.04 and Ubuntu 22.04
+# ROS2CS - Ubuntu 20.04 / 22.04 / 24.04 (legacy - not recently verified)
 
 > Modifications Copyright (c) 2026 Jianbin Liu.
 >
 > Modifications by Jianbin Liu:
 > - Marked Ubuntu instructions as legacy / not recently verified for the current Jazzy maintenance branch.
 > - Noted the .NET 8 tests/examples target framework change without rewriting the Ubuntu flow.
+> - Refreshed SDK and ROS sourcing examples to avoid stale .NET 6 / Foxy copy-paste paths.
 
 ## Current verification status
 
@@ -17,7 +18,9 @@ The current target framework split is:
 - `ros2cs_common`, `ros2cs_core`, and generated message assemblies: `netstandard2.0`.
 - `ros2cs_tests` and `ros2cs_examples`: `net8.0`.
 
-The older `.NET 6.0` references below are retained as historical setup context and need refresh before claiming Ubuntu support for this branch.
+The Ubuntu flow below still needs a fresh build/test run before claiming support
+for this branch, but the SDK and ROS sourcing commands now match the current
+target framework split.
 
 ## Building
 
@@ -27,7 +30,7 @@ The older `.NET 6.0` references below are retained as historical setup context a
 
 - ROS2 installed on the system, along with `test-msgs`, `cyclonedds` and `fastrtps` packages
 - vcstool package - [see here](https://github.com/dirk-thomas/vcstool)
-- .NET 6.0 sdk - [see here](https://www.microsoft.com/net/learn/get-started)
+- .NET 8 SDK - [see here](https://www.microsoft.com/net/learn/get-started)
 
 
 ```bash
@@ -46,11 +49,11 @@ wget https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-mi
 sudo dpkg -i packages-microsoft-prod.deb
 rm packages-microsoft-prod.deb
 
-# install .NET core 6.0 SDK
+# Install .NET 8 SDK
 sudo apt-get update; \
   sudo apt-get install -y apt-transport-https && \
   sudo apt-get update && \
-  sudo apt-get install -y dotnet-sdk-6.0
+  sudo apt-get install -y dotnet-sdk-8.0
 ```
 
 **Optional**
@@ -66,8 +69,7 @@ sudo apt install patchelf
 - Clone this project
 - Source your ROS2 installation
   ```bash
-  # Change foxy to whatever version you are using
-  source /opt/ros/foxy/setup.bash
+  source /opt/ros/${ROS_DISTRO}/setup.bash
   ```
 - Navigate to the top project folder and pull required repositories
   ```bash

--- a/README-WINDOWS.md
+++ b/README-WINDOWS.md
@@ -20,7 +20,7 @@ Current GREEN evidence for this maintenance branch is:
 - `ros2cs` source workspace build/test.
 - `ros2cs_common`, `ros2cs_core`, and generated message assemblies on `netstandard2.0`.
 - `ros2cs_tests` and `ros2cs_examples` on `net8.0`.
-- Latest public maintenance preview: [`v0.2.0-jazzy-preview.1`](https://github.com/JianbinLiu-CFLab/ros2cs/releases/tag/v0.2.0-jazzy-preview.1).
+- Latest public maintenance preview: [`v0.3.0-jazzy-preview.1`](https://github.com/JianbinLiu-CFLab/ros2cs/releases/tag/v0.3.0-jazzy-preview.1).
 
 Windows 11 is an expected target but was not the OS used for the current local validation. Older ROS 2 distributions in this README are legacy context unless fresh evidence is added.
 

--- a/README-WINDOWS.md
+++ b/README-WINDOWS.md
@@ -20,6 +20,7 @@ Current GREEN evidence for this maintenance branch is:
 - `ros2cs` source workspace build/test.
 - `ros2cs_common`, `ros2cs_core`, and generated message assemblies on `netstandard2.0`.
 - `ros2cs_tests` and `ros2cs_examples` on `net8.0`.
+- Latest public maintenance preview: [`v0.2.0-jazzy-preview.1`](https://github.com/JianbinLiu-CFLab/ros2cs/releases/tag/v0.2.0-jazzy-preview.1).
 
 Windows 11 is an expected target but was not the OS used for the current local validation. Older ROS 2 distributions in this README are legacy context unless fresh evidence is added.
 

--- a/README-WINDOWS.md
+++ b/README-WINDOWS.md
@@ -20,7 +20,7 @@ Current GREEN evidence for this maintenance branch is:
 - `ros2cs` source workspace build/test.
 - `ros2cs_common`, `ros2cs_core`, and generated message assemblies on `netstandard2.0`.
 - `ros2cs_tests` and `ros2cs_examples` on `net8.0`.
-- Latest public maintenance preview: [`v0.4.0-jazzy-preview.1`](https://github.com/JianbinLiu-CFLab/ros2cs/releases/tag/v0.4.0-jazzy-preview.1).
+- Latest public maintenance preview: [`v0.5.0-jazzy-preview.1`](https://github.com/JianbinLiu-CFLab/ros2cs/releases/tag/v0.5.0-jazzy-preview.1).
 
 Windows 11 is an expected target but was not the OS used for the current local validation. Older ROS 2 distributions in this README are legacy context unless fresh evidence is added.
 

--- a/README-WINDOWS.md
+++ b/README-WINDOWS.md
@@ -20,7 +20,7 @@ Current GREEN evidence for this maintenance branch is:
 - `ros2cs` source workspace build/test.
 - `ros2cs_common`, `ros2cs_core`, and generated message assemblies on `netstandard2.0`.
 - `ros2cs_tests` and `ros2cs_examples` on `net8.0`.
-- Latest public maintenance preview: [`v0.3.1-jazzy-preview.1`](https://github.com/JianbinLiu-CFLab/ros2cs/releases/tag/v0.3.1-jazzy-preview.1).
+- Latest public maintenance preview: [`v0.4.0-jazzy-preview.1`](https://github.com/JianbinLiu-CFLab/ros2cs/releases/tag/v0.4.0-jazzy-preview.1).
 
 Windows 11 is an expected target but was not the OS used for the current local validation. Older ROS 2 distributions in this README are legacy context unless fresh evidence is added.
 

--- a/README-WINDOWS.md
+++ b/README-WINDOWS.md
@@ -60,10 +60,8 @@ Windows 11 is an expected target but was not the OS used for the current local v
   - You can build tests by adding `--with-tests` argument
 - To test your build please check main readme [Testing section](README.md#testing)
 
-Current local validation commands are recorded in:
-
-- `D:\ros2unity\plan\ros2cs\06-ros2cs-jazzy-build-test-validation-report.md`
-- `D:\ros2unity\plan\ros2cs\07-ros2cs-src-workspace-build-test-validation.md`
+Record validation commands, exit codes, and key output in your local release or
+maintenance notes before making platform support claims.
 
 ### Standalone version (Windows)
 
@@ -104,6 +102,7 @@ This indicates colcon/CMake tried to infer a Visual Studio generator from a Visu
 colcon build --cmake-args -G Ninja
 ```
 
-When using the local Jazzy wrapper, `D:\ros2unity\tools\Enter-Ros2JazzyEnv.py` sets `CMAKE_GENERATOR=Ninja` by default. Explicit `--cmake-args -G Ninja` is still recommended in reproducible command logs.
+Set `CMAKE_GENERATOR=Ninja` in the sourced ROS 2 / MSVC environment, or pass
+`--cmake-args -G Ninja` explicitly in reproducible command logs.
 
 **If no solution of your problem is present in the section above, please make sure to check out `ROS2 For Unity` [Troubleshooting section](https://github.com/RobotecAI/ros2-for-unity/blob/master/README-WINDOWS.md#build-troubleshooting)**

--- a/README-WINDOWS.md
+++ b/README-WINDOWS.md
@@ -20,7 +20,7 @@ Current GREEN evidence for this maintenance branch is:
 - `ros2cs` source workspace build/test.
 - `ros2cs_common`, `ros2cs_core`, and generated message assemblies on `netstandard2.0`.
 - `ros2cs_tests` and `ros2cs_examples` on `net8.0`.
-- Latest public maintenance preview: [`v0.3.0-jazzy-preview.1`](https://github.com/JianbinLiu-CFLab/ros2cs/releases/tag/v0.3.0-jazzy-preview.1).
+- Latest public maintenance preview: [`v0.3.1-jazzy-preview.1`](https://github.com/JianbinLiu-CFLab/ros2cs/releases/tag/v0.3.1-jazzy-preview.1).
 
 Windows 11 is an expected target but was not the OS used for the current local validation. Older ROS 2 distributions in this README are legacy context unless fresh evidence is added.
 

--- a/README-WINDOWS.md
+++ b/README-WINDOWS.md
@@ -1,19 +1,43 @@
-# ROS2CS - Windows 10
+# ROS2CS - Windows 10 / Windows 10 LTSC / Windows 11
+
+> Modifications Copyright (c) 2026 Jianbin Liu.
+>
+> Modifications by Jianbin Liu:
+> - Documented the Jazzy/FastRTPS RTI Connext DDS Micro probe stderr as a known non-blocking environment warning.
+> - Documented Ninja as the required Windows Jazzy generator policy for VS 2026 / VS 18 toolchains.
+> - Updated the current Windows verification status for Windows 10 LTSC + ROS 2 Jazzy and .NET 8 tests/examples.
 
 ## Building
 
+### Current verification status
+
+Current GREEN evidence for this maintenance branch is:
+
+- Windows 10 IoT Enterprise LTSC 2021 (`10.0.19044`).
+- ROS 2 Jazzy from the local pixi-based Windows distribution.
+- `RMW_IMPLEMENTATION=rmw_fastrtps_cpp`.
+- MSVC compiler with Ninja generator.
+- `ros2cs` source workspace build/test.
+- `ros2cs_common`, `ros2cs_core`, and generated message assemblies on `netstandard2.0`.
+- `ros2cs_tests` and `ros2cs_examples` on `net8.0`.
+
+Windows 11 is an expected target but was not the OS used for the current local validation. Older ROS 2 distributions in this README are legacy context unless fresh evidence is added.
+
 ### Prerequisites
 
-*  ROS2 installed on the system (additionally you should go to [Building ROS2 section](https://docs.ros.org/en/foxy/Installation/Windows-Development-Setup.html) and check if all `pip` [Install dependencies](https://docs.ros.org/en/foxy/Installation/Windows-Development-Setup.html#install-dependencies) and [Developer tools](https://docs.ros.org/en/foxy/Installation/Windows-Development-Setup.html#install-developer-tools) are installed)
+*  ROS2 installed on the system. For this maintenance branch, the verified target is ROS 2 Jazzy.
 *  vcstool package - [see here](https://github.com/dirk-thomas/vcstool)
-*  .NET 6.0 sdk - [see here](https://dotnet.microsoft.com/download/dotnet/6.0)
-*  For tests only: xUnit testing framework - [see here](https://xunit.net/)
+*  .NET 8 SDK for tests/examples.
+*  `ros2cs_common`, `ros2cs_core`, and generated message assemblies remain compatible with `netstandard2.0`.
+*  For tests only: NUnit test infrastructure as configured by `ros2cs_tests`.
 
 ### Important notices
 
 - Windows [path length is limited to 260 characters](https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation) by default. A good solution is to modify your `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem` registry key `LongPathsEnabled` to 1. This way you will avoid path length issues. Alternatively, you need to clone your repo to `C:\dev` into `r2cs` folder or a similar shallow path to avoid this issue during build. **Cloning into longer path will cause compilation errors!**
 
-- For building and running a Visual Studio preconfigured powershell terminal must be used. Standard powershell prompt might not be configured properly to be used with MSVC compiler and Windows SDKs.  You should have Visual Studio already installed (ROS2 dependency) and you can find shortcut for `Developer PowerShell for VS` here: `C:\ProgramData\Microsoft\Windows\Start Menu\Programs\Visual Studio 2019\Visual Studio Tools`.
+- For building and running, an MSVC/Visual Studio configured PowerShell terminal must be used. Standard PowerShell may not have the compiler and Windows SDK paths configured. Visual Studio 2022 and Visual Studio 2026 / VS 18 toolchains are both acceptable compiler environments when Ninja is used.
+
+- Windows Jazzy builds should use the Ninja generator with MSVC (`-G Ninja` or `CMAKE_GENERATOR=Ninja`). Visual Studio 2026 / VS 18 environments are valid compiler environments, but the Jazzy-pinned `colcon_cmake` and CMake versions do not support auto-selecting a Visual Studio 18 generator. Do not rely on colcon's automatic Visual Studio generator detection.
 
 - A powershell terminal with administrator privileges is required for **Windows** and **ros2 galactic**. This is because python packages installation requires a privilage for creating symlinks. More about this issue: [github issue](https://github.com/ament/ament_cmake/issues/350).
 
@@ -24,7 +48,9 @@
 ### Steps
 
 - Clone this project.
-- Source your ROS2 installation (`C:\dev\ros2_foxy\local_setup.ps1`)
+- Source your ROS2 installation.
+  - Legacy example: `C:\dev\ros2_foxy\local_setup.ps1`
+  - Current maintenance target: ROS 2 Jazzy.
 - Navigate to the top project folder and pull required repositories (`get_repos.ps1`)
   - You can run script with `--get-custom-messages` argument to fetch extra messages from `custom_messages.repos` file.
   - It will use `vcstool` to download required ROS2 packages. By default, this will get repositories as set in `${ROS_DISTRO}`.
@@ -32,6 +58,11 @@
   - It invokes `colcon_build` with `--merge-install` argument to simplify libraries installation
   - You can build tests by adding `--with-tests` argument
 - To test your build please check main readme [Testing section](README.md#testing)
+
+Current local validation commands are recorded in:
+
+- `D:\ros2unity\plan\ros2cs\06-ros2cs-jazzy-build-test-validation-report.md`
+- `D:\ros2unity\plan\ros2cs\07-ros2cs-src-workspace-build-test-validation.md`
 
 ### Standalone version (Windows)
 
@@ -50,5 +81,28 @@ Additionally all libraries need to be in a visible path, since they are loaded d
 Problem may occur on non english version of Windows. This error is caused by impossibility in decoding `dotnet` output by ament tools.
 
 **Fix**: Change your `dotnet` output to english by temporarily renaming your localization directory (`pl` to `pl.bak`, `fr` to `fr.bak` etc.) in your `dotnet` sdk directory.
+
+- Known non-blocking stderr: `ERRORFailed to load RTI Connext DDS Micro`
+
+Windows Jazzy + FastRTPS builds may print this line while generating interface typesupport. It comes from the ROS 2 `rmw_implementation` loader probing the installed `rmw_connextddsmicro_cpp` plugin without an RTI Connext DDS Micro runtime. It is not a ros2cs code path.
+
+Treat it as non-blocking environment noise only when all of these are true:
+
+- `RMW_IMPLEMENTATION=rmw_fastrtps_cpp`
+- `colcon build` exits with code 0
+- `colcon test` exits with code 0 and the CTest `Test.xml` / NUnit output has 0 failures
+- the message appears only in interface package stderr, not in ros2cs C# or native shim compile/link stderr
+
+Re-evaluate if you switch to `rmw_connextddsmicro_cpp`, install RTI Connext DDS Micro runtime, or any of the conditions above stop being true.
+
+- `Unknown / unsupported VS version '18.0'`
+
+This indicates colcon/CMake tried to infer a Visual Studio generator from a Visual Studio 2026 / VS 18 environment. Use Ninja instead:
+
+```powershell
+colcon build --cmake-args -G Ninja
+```
+
+When using the local Jazzy wrapper, `D:\ros2unity\tools\Enter-Ros2JazzyEnv.py` sets `CMAKE_GENERATOR=Ninja` by default. Explicit `--cmake-args -G Ninja` is still recommended in reproducible command logs.
 
 **If no solution of your problem is present in the section above, please make sure to check out `ROS2 For Unity` [Troubleshooting section](https://github.com/RobotecAI/ros2-for-unity/blob/master/README-WINDOWS.md#build-troubleshooting)**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 Ros2cs
 =============
 
+> Modifications Copyright (c) 2026 Jianbin Liu.
+>
+> Modifications by Jianbin Liu:
+> - Documented the current conservative verification status for the Jazzy maintenance branch.
+> - Clarified Windows 10 LTSC validation, .NET target framework split, and legacy Ubuntu status.
+
 A C# .NET library for ROS2, including C# implementation of rcl APIs, message generation, tests and examples.
 
 Ros2cs is also an independent part of [Ros2 For Unity](https://github.com/RobotecAI/ros2-for-unity), which enables high-performance communication between simulation and ROS2 robot packages. Follow instructions there instead if you are intending to use ros2cs with Unity3D.
@@ -12,18 +18,38 @@ Ros2cs is also an independent part of [Ros2 For Unity](https://github.com/Robote
 - Custom messages can be easily generated from unmodified ROS2 packages
 - A logger that can be hooked to your application callbacks (e.g. in Unity3D)
 
-### Platforms
+### Current verification status
 
-Supported OSes:
+This maintenance branch keeps the historical ros2cs platform goals, but current GREEN evidence is narrower than the legacy support matrix below.
+
+Verified in the current local validation:
+
+- Windows 10 IoT Enterprise LTSC 2021 (`10.0.19044`) with ROS 2 Jazzy.
+- `RMW_IMPLEMENTATION=rmw_fastrtps_cpp`.
+- MSVC toolchain with Ninja generator.
+- `ros2cs` workspace build/test for the Jazzy source workspace.
+- `ros2cs_common`, `ros2cs_core`, and generated message assemblies remain `netstandard2.0`.
+- `ros2cs_tests` and `ros2cs_examples` target `net8.0`.
+
+Not yet verified in the current maintenance round:
+
+- Ubuntu 20.04 / 22.04 / 24.04.
+- Windows 11.
+- ROS 2 Foxy / Galactic / Humble / Rolling on this branch.
+- Unity / R2FU runtime import and Player validation.
+
+### Platform goals and legacy matrix
+
+Historical/project OS targets:
 - Ubuntu 24.04 (bash)
 - Ubuntu 22.04 (bash)
 - Ubuntu 20.04 (bash)
-- Windows 10* (powershell)
-- Windows 11* (powershell)
+- Windows 10 / Windows 10 LTSC (powershell)
+- Windows 11 (powershell)
 
-> \* ROS2 Galactic and Humble support only Windows 10 ([ROS 2 Windows system requirements](https://docs.ros.org/en/humble/Installation/Windows-Install-Binary.html#system-requirements)), but it is proven that it also works fine on Windows 11.
+> The current Jazzy validation evidence is Windows 10 LTSC only. Treat Windows 11 and Ubuntu entries as expected or legacy targets until they have fresh build/test evidence.
 
-Supported ROS2 distributions:
+Historical/project ROS2 distribution targets:
 - Jazzy
 - Humble
 - Galactic
@@ -43,16 +69,16 @@ After cloning the project and importing .repos, you can simply put your message 
 
 ### Build instructions
 
-Please follow the  OS-specific instructions for your build:
+Please follow the OS-specific instructions for your build:
 
-- [Ubuntu 20.04 Instructions](README-UBUNTU.md)
-- [Windows 10 Instructions](README-WINDOWS.md)
+- [Ubuntu Instructions](README-UBUNTU.md) - legacy, not recently verified for this Jazzy maintenance branch
+- [Windows Instructions](README-WINDOWS.md) - current validation target is Windows 10 LTSC + Jazzy
 
 ## Testing
 
-Make sure your NuGet repositories can resolve `xUnit` dependency. You can call `dotnet nuget list source` to see your current sources for NuGet packages. Please note that `Microsoft Visual Studio Offline Packages` are usually insufficient. You can fix it by adding `nuget.org` repository: `dotnet nuget add source --name nuget.org https://api.nuget.org/v3/index.json`.
+Make sure your NuGet repositories can resolve the test dependencies used by `ros2cs_tests` (currently NUnit-based). You can call `dotnet nuget list source` to see your current sources for NuGet packages. Please note that `Microsoft Visual Studio Offline Packages` are usually insufficient. You can fix it by adding `nuget.org` repository: `dotnet nuget add source --name nuget.org https://api.nuget.org/v3/index.json`.
 
-- Make sure you built tests ( OS-specific build script with `--with-tests` flag).
+- Make sure you built tests (OS-specific build script with `--with-tests` flag).
 - Run OS-specific test script:
     - ubuntu:
     ```bash
@@ -60,7 +86,7 @@ Make sure your NuGet repositories can resolve `xUnit` dependency. You can call `
     ```
     - windows:
     ```powershell
-    test.sp1
+    test.ps1
     ```
 - Run a manual test with basic listener/publisher examples (you have to source your ROS2 first):
     - ubuntu

--- a/README.md
+++ b/README.md
@@ -15,16 +15,19 @@ Ros2cs is also an independent part of [Ros2 For Unity](https://github.com/Robote
 ### Platforms
 
 Supported OSes:
+- Ubuntu 24.04 (bash)
 - Ubuntu 22.04 (bash)
 - Ubuntu 20.04 (bash)
-- Windows 10 (powershell)
-- Windows 11* (powershel)
+- Windows 10* (powershell)
+- Windows 11* (powershell)
 
 > \* ROS2 Galactic and Humble support only Windows 10 ([ROS 2 Windows system requirements](https://docs.ros.org/en/humble/Installation/Windows-Install-Binary.html#system-requirements)), but it is proven that it also works fine on Windows 11.
 
 Supported ROS2 distributions:
-- Galactic
+- Jazzy
 - Humble
+- Galactic
+- Foxy
 
 ### Flavours
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ version: main
 The latest public maintenance preview is:
 
 ```text
-v0.4.0-jazzy-preview.1
-https://github.com/JianbinLiu-CFLab/ros2cs/releases/tag/v0.4.0-jazzy-preview.1
+v0.5.0-jazzy-preview.1
+https://github.com/JianbinLiu-CFLab/ros2cs/releases/tag/v0.5.0-jazzy-preview.1
 ```
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ version: main
 The latest public maintenance preview is:
 
 ```text
-v0.3.0-jazzy-preview.1
-https://github.com/JianbinLiu-CFLab/ros2cs/releases/tag/v0.3.0-jazzy-preview.1
+v0.3.1-jazzy-preview.1
+https://github.com/JianbinLiu-CFLab/ros2cs/releases/tag/v0.3.1-jazzy-preview.1
 ```
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ version: main
 The latest public maintenance preview is:
 
 ```text
-v0.2.0-jazzy-preview.1
-https://github.com/JianbinLiu-CFLab/ros2cs/releases/tag/v0.2.0-jazzy-preview.1
+v0.3.0-jazzy-preview.1
+https://github.com/JianbinLiu-CFLab/ros2cs/releases/tag/v0.3.0-jazzy-preview.1
 ```
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ https://github.com/JianbinLiu-CFLab/ros2cs.git
 version: main
 ```
 
+The latest public maintenance preview is:
+
+```text
+v0.2.0-jazzy-preview.1
+https://github.com/JianbinLiu-CFLab/ros2cs/releases/tag/v0.2.0-jazzy-preview.1
+```
+
 ### Features
 
 - A set of core abstractions such as Node, Publisher, Subscription, QoS, Clock

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ version: main
 The latest public maintenance preview is:
 
 ```text
-v0.3.1-jazzy-preview.1
-https://github.com/JianbinLiu-CFLab/ros2cs/releases/tag/v0.3.1-jazzy-preview.1
+v0.4.0-jazzy-preview.1
+https://github.com/JianbinLiu-CFLab/ros2cs/releases/tag/v0.4.0-jazzy-preview.1
 ```
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -6,10 +6,24 @@ Ros2cs
 > Modifications by Jianbin Liu:
 > - Documented the current conservative verification status for the Jazzy maintenance branch.
 > - Clarified Windows 10 LTSC validation, .NET target framework split, and legacy Ubuntu status.
+> - Declared the JianbinLiu-CFLab `main` branch as the maintained integration line.
 
 A C# .NET library for ROS2, including C# implementation of rcl APIs, message generation, tests and examples.
 
 Ros2cs is also an independent part of [Ros2 For Unity](https://github.com/RobotecAI/ros2-for-unity), which enables high-performance communication between simulation and ROS2 robot packages. Follow instructions there instead if you are intending to use ros2cs with Unity3D.
+
+### Maintained integration line
+
+For the JianbinLiu-CFLab fork, `main` is the maintained integration line.
+
+The upstream RobotecAI repository and its historical branches remain the original source and licensing history, but they are no longer used as the active integration target for this Jazzy/R2FU line. Upstream changes should be reviewed and cherry-picked deliberately rather than merged blindly.
+
+Downstream projects should consume:
+
+```text
+https://github.com/JianbinLiu-CFLab/ros2cs.git
+version: main
+```
 
 ### Features
 

--- a/README.md
+++ b/README.md
@@ -18,19 +18,24 @@ For the JianbinLiu-CFLab fork, `main` is the maintained integration line.
 
 The upstream RobotecAI repository and its historical branches remain the original source and licensing history, but they are no longer used as the active integration target for this Jazzy/R2FU line. Upstream changes should be reviewed and cherry-picked deliberately rather than merged blindly.
 
-Downstream projects should consume:
+Downstream projects should use the latest public maintenance preview for a
+stable, reproducible pin:
+
+```text
+https://github.com/JianbinLiu-CFLab/ros2cs.git
+version: v0.5.0-jazzy-preview.1
+```
+
+Use `main` only when intentionally tracking current development:
 
 ```text
 https://github.com/JianbinLiu-CFLab/ros2cs.git
 version: main
 ```
 
-The latest public maintenance preview is:
+Release notes and artifacts:
 
-```text
-v0.5.0-jazzy-preview.1
-https://github.com/JianbinLiu-CFLab/ros2cs/releases/tag/v0.5.0-jazzy-preview.1
-```
+- https://github.com/JianbinLiu-CFLab/ros2cs/releases/tag/v0.5.0-jazzy-preview.1
 
 ### Features
 
@@ -75,6 +80,7 @@ Historical/project ROS2 distribution targets:
 - Humble
 - Galactic
 - Foxy
+- Rolling (repository file present, unmaintained on this fork)
 
 ### Flavours
 

--- a/build.ps1
+++ b/build.ps1
@@ -8,6 +8,13 @@
     build with tests
 .PARAMETER standalone
     standalone build
+
+Modifications Copyright (c) 2026 Jianbin Liu.
+
+Modifications by Jianbin Liu:
+- Defaulted Windows builds to Ninja for ROS 2 Jazzy/MSVC stability and speed.
+- Added explicit parallel worker selection with ROS2CS_PARALLEL_WORKERS override.
+- Added optional compiler launcher support through ROS2CS_COMPILER_LAUNCHER or sccache auto-detection.
 #>
 Param (
     [Parameter(Mandatory=$false)][switch]$with_tests=$false,
@@ -18,6 +25,7 @@ $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
 function Get-ParallelWorkers {
+    # Worker count is a throughput policy; build correctness must not depend on a specific value.
     if (-not [string]::IsNullOrWhiteSpace($Env:ROS2CS_PARALLEL_WORKERS)) {
         $workers = 0
         if ([int]::TryParse($Env:ROS2CS_PARALLEL_WORKERS, [ref]$workers) -and $workers -gt 0) {
@@ -30,6 +38,7 @@ function Get-ParallelWorkers {
 }
 
 function Get-CompilerLauncher {
+    # Compiler launcher use is best-effort acceleration and must not be required for a correct build.
     if (-not [string]::IsNullOrWhiteSpace($Env:ROS2CS_COMPILER_LAUNCHER)) {
         return $Env:ROS2CS_COMPILER_LAUNCHER
     }

--- a/build.ps1
+++ b/build.ps1
@@ -17,6 +17,31 @@ Param (
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
+function Get-ParallelWorkers {
+    if (-not [string]::IsNullOrWhiteSpace($Env:ROS2CS_PARALLEL_WORKERS)) {
+        $workers = 0
+        if ([int]::TryParse($Env:ROS2CS_PARALLEL_WORKERS, [ref]$workers) -and $workers -gt 0) {
+            return $workers
+        }
+        throw "ROS2CS_PARALLEL_WORKERS must be a positive integer."
+    }
+
+    return [System.Environment]::ProcessorCount
+}
+
+function Get-CompilerLauncher {
+    if (-not [string]::IsNullOrWhiteSpace($Env:ROS2CS_COMPILER_LAUNCHER)) {
+        return $Env:ROS2CS_COMPILER_LAUNCHER
+    }
+
+    $sccache = Get-Command sccache -ErrorAction SilentlyContinue
+    if ($null -ne $sccache) {
+        return "sccache"
+    }
+
+    return $null
+}
+
 if ([string]::IsNullOrEmpty($Env:ROS_DISTRO)) {
     Write-Host "Source your ros2 distro first (foxy, galactic, humble, jazzy or rolling are supported)" -ForegroundColor Red
     exit 1
@@ -34,8 +59,33 @@ if($standalone) {
     $standalone_switch="ON"
 }
 
+$parallelWorkers = Get-ParallelWorkers
+$compilerLauncher = Get-CompilerLauncher
+$cmakeArgs = @(
+    "-G", "Ninja",
+    "-DSTANDALONE_BUILD=$standalone_switch",
+    "-DCMAKE_BUILD_TYPE=Release",
+    "-DBUILD_TESTING=$tests_switch"
+)
+
+if (-not [string]::IsNullOrWhiteSpace($compilerLauncher)) {
+    $cmakeArgs += "-DCMAKE_C_COMPILER_LAUNCHER=$compilerLauncher"
+    $cmakeArgs += "-DCMAKE_CXX_COMPILER_LAUNCHER=$compilerLauncher"
+    $msg += " (compiler launcher: $compilerLauncher)"
+}
+
+$colconArgs = @(
+    "build",
+    "--parallel-workers", "$parallelWorkers",
+    "--merge-install",
+    "--event-handlers", "console_direct+",
+    "--cmake-args"
+) + $cmakeArgs
+
+$msg += " (workers: $parallelWorkers, generator: Ninja)"
+
 Write-Host $msg -ForegroundColor Green
-colcon build --merge-install --event-handlers console_direct+ --cmake-args -DSTANDALONE_BUILD=$standalone_switch -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=$tests_switch
+colcon @colconArgs
 if ($LASTEXITCODE -ne 0) {
     exit $LASTEXITCODE
 }

--- a/build.ps1
+++ b/build.ps1
@@ -14,6 +14,14 @@ Param (
     [Parameter(Mandatory=$false)][switch]$standalone=$false
 )
 
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+if ([string]::IsNullOrEmpty($Env:ROS_DISTRO)) {
+    Write-Host "Source your ros2 distro first (foxy, galactic, humble, jazzy or rolling are supported)" -ForegroundColor Red
+    exit 1
+}
+
 $msg="Build started."
 $tests_switch=0
 if($with_tests) {
@@ -28,3 +36,6 @@ if($standalone) {
 
 Write-Host $msg -ForegroundColor Green
 colcon build --merge-install --event-handlers console_direct+ --cmake-args -DSTANDALONE_BUILD:int=$standalone_switch -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING:int=$tests_switch --no-warn-unused-cli
+if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}

--- a/build.ps1
+++ b/build.ps1
@@ -23,19 +23,19 @@ if ([string]::IsNullOrEmpty($Env:ROS_DISTRO)) {
 }
 
 $msg="Build started."
-$tests_switch=0
+$tests_switch="OFF"
 if($with_tests) {
     $msg+=" (with tests)"
-    $tests_switch=1
+    $tests_switch="ON"
 }
-$standalone_switch=0
+$standalone_switch="OFF"
 if($standalone) {
     $msg+=" (standalone)"
-    $standalone_switch=1
+    $standalone_switch="ON"
 }
 
 Write-Host $msg -ForegroundColor Green
-colcon build --merge-install --event-handlers console_direct+ --cmake-args -DSTANDALONE_BUILD:int=$standalone_switch -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING:int=$tests_switch --no-warn-unused-cli
+colcon build --merge-install --event-handlers console_direct+ --cmake-args -DSTANDALONE_BUILD=$standalone_switch -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=$tests_switch
 if ($LASTEXITCODE -ne 0) {
     exit $LASTEXITCODE
 }

--- a/build.ps1
+++ b/build.ps1
@@ -8,6 +8,8 @@
     build with tests
 .PARAMETER standalone
     standalone build
+.PARAMETER build_base
+    Optional colcon build base directory. Can also be set with ROS2CS_BUILD_BASE.
 
 Modifications Copyright (c) 2026 Jianbin Liu.
 
@@ -15,10 +17,12 @@ Modifications by Jianbin Liu:
 - Defaulted Windows builds to Ninja for ROS 2 Jazzy/MSVC stability and speed.
 - Added explicit parallel worker selection with ROS2CS_PARALLEL_WORKERS override.
 - Added optional compiler launcher support through ROS2CS_COMPILER_LAUNCHER or sccache auto-detection.
+- Added optional short colcon build base support through -build_base or ROS2CS_BUILD_BASE.
 #>
 Param (
     [Parameter(Mandatory=$false)][switch]$with_tests=$false,
-    [Parameter(Mandatory=$false)][switch]$standalone=$false
+    [Parameter(Mandatory=$false)][switch]$standalone=$false,
+    [Parameter(Mandatory=$false)][string]$build_base=$Env:ROS2CS_BUILD_BASE
 )
 
 $ErrorActionPreference = 'Stop'
@@ -83,8 +87,14 @@ if (-not [string]::IsNullOrWhiteSpace($compilerLauncher)) {
     $msg += " (compiler launcher: $compilerLauncher)"
 }
 
-$colconArgs = @(
-    "build",
+$colconArgs = @("build")
+
+if (-not [string]::IsNullOrWhiteSpace($build_base)) {
+    $colconArgs += @("--build-base", "$build_base")
+    $msg += " (build base: $build_base)"
+}
+
+$colconArgs += @(
     "--parallel-workers", "$parallelWorkers",
     "--merge-install",
     "--event-handlers", "console_direct+",

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+# Modifications Copyright (c) 2026 Jianbin Liu.
+#
+# Modifications by Jianbin Liu:
+# - Added explicit parallel worker selection with ROS2CS_PARALLEL_WORKERS override.
+# - Added optional compiler launcher support through ROS2CS_COMPILER_LAUNCHER or ccache auto-detection.
+
 set -euo pipefail
 
 display_usage() {
@@ -20,6 +26,7 @@ MSG="Build started."
 STANDALONE=OFF
 PARALLEL_WORKERS="${ROS2CS_PARALLEL_WORKERS:-}"
 
+# Worker count is a throughput policy; build correctness must not depend on a specific value.
 if [ -z "$PARALLEL_WORKERS" ]; then
   if command -v nproc >/dev/null 2>&1; then
     PARALLEL_WORKERS="$(nproc)"
@@ -43,6 +50,7 @@ if [ "$PARALLEL_WORKERS" -lt 1 ]; then
 fi
 
 COMPILER_LAUNCHER="${ROS2CS_COMPILER_LAUNCHER:-}"
+# Compiler launcher use is best-effort acceleration and must not be required for a correct build.
 if [ -z "$COMPILER_LAUNCHER" ] && command -v ccache >/dev/null 2>&1; then
   COMPILER_LAUNCHER="ccache"
 fi

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ display_usage() {
 }
 
 if [ -z "${ROS_DISTRO}" ]; then
-    echo "Source your ros2 distro first (foxy, galactic, humble or rolling are supported)"
+    echo "Source your ros2 distro first (foxy, galactic, humble, jazzy or rolling are supported)"
     exit 1
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,7 @@ if [ -z "${ROS_DISTRO:-}" ]; then
     exit 1
 fi
 
-TESTS=0
+TESTS=OFF
 MSG="Build started."
 STANDALONE=OFF
 
@@ -23,7 +23,7 @@ while [[ $# -gt 0 ]]; do
   key="$1"
   case $key in
     -t|--with-tests)
-      TESTS=1
+      TESTS=ON
       MSG="$MSG (with tests)"
       shift # past argument
       ;;
@@ -52,5 +52,4 @@ colcon build \
 -DCMAKE_BUILD_TYPE=Release \
 -DSTANDALONE_BUILD=$STANDALONE \
 -DBUILD_TESTING=$TESTS \
--DCMAKE_SHARED_LINKER_FLAGS="-Wl,-rpath,'\$ORIGIN',-rpath=.,--disable-new-dtags" \
---no-warn-unused-cli
+-DCMAKE_SHARED_LINKER_FLAGS="-Wl,-rpath,'\$ORIGIN',-rpath=.,--disable-new-dtags"

--- a/build.sh
+++ b/build.sh
@@ -18,6 +18,34 @@ fi
 TESTS=OFF
 MSG="Build started."
 STANDALONE=OFF
+PARALLEL_WORKERS="${ROS2CS_PARALLEL_WORKERS:-}"
+
+if [ -z "$PARALLEL_WORKERS" ]; then
+  if command -v nproc >/dev/null 2>&1; then
+    PARALLEL_WORKERS="$(nproc)"
+  elif command -v getconf >/dev/null 2>&1; then
+    PARALLEL_WORKERS="$(getconf _NPROCESSORS_ONLN)"
+  else
+    PARALLEL_WORKERS="1"
+  fi
+fi
+
+case "$PARALLEL_WORKERS" in
+  ''|*[!0-9]*)
+    echo "ROS2CS_PARALLEL_WORKERS must be a positive integer"
+    exit 1
+    ;;
+esac
+
+if [ "$PARALLEL_WORKERS" -lt 1 ]; then
+  echo "ROS2CS_PARALLEL_WORKERS must be a positive integer"
+  exit 1
+fi
+
+COMPILER_LAUNCHER="${ROS2CS_COMPILER_LAUNCHER:-}"
+if [ -z "$COMPILER_LAUNCHER" ] && command -v ccache >/dev/null 2>&1; then
+  COMPILER_LAUNCHER="ccache"
+fi
 
 while [[ $# -gt 0 ]]; do
   key="$1"
@@ -44,12 +72,27 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+CMAKE_ARGS=(
+  -DCMAKE_BUILD_TYPE=Release
+  -DSTANDALONE_BUILD="$STANDALONE"
+  -DBUILD_TESTING="$TESTS"
+  -DCMAKE_SHARED_LINKER_FLAGS="-Wl,-rpath,'\$ORIGIN',-rpath=.,--disable-new-dtags"
+)
+
+if [ -n "$COMPILER_LAUNCHER" ]; then
+  CMAKE_ARGS+=(
+    -DCMAKE_C_COMPILER_LAUNCHER="$COMPILER_LAUNCHER"
+    -DCMAKE_CXX_COMPILER_LAUNCHER="$COMPILER_LAUNCHER"
+  )
+  MSG="$MSG (compiler launcher: $COMPILER_LAUNCHER)"
+fi
+
+MSG="$MSG (workers: $PARALLEL_WORKERS)"
+
 echo "$MSG"
 colcon build \
+--parallel-workers "$PARALLEL_WORKERS" \
 --merge-install \
 --event-handlers console_direct+ \
 --cmake-args \
--DCMAKE_BUILD_TYPE=Release \
--DSTANDALONE_BUILD=$STANDALONE \
--DBUILD_TESTING=$TESTS \
--DCMAKE_SHARED_LINKER_FLAGS="-Wl,-rpath,'\$ORIGIN',-rpath=.,--disable-new-dtags"
+"${CMAKE_ARGS[@]}"

--- a/build.sh
+++ b/build.sh
@@ -4,16 +4,18 @@
 # Modifications by Jianbin Liu:
 # - Added explicit parallel worker selection with ROS2CS_PARALLEL_WORKERS override.
 # - Added optional compiler launcher support through ROS2CS_COMPILER_LAUNCHER or ccache auto-detection.
+# - Added optional short colcon build base support through --build-base or ROS2CS_BUILD_BASE.
 
 set -euo pipefail
 
 display_usage() {
     echo "Usage: "
-    echo "build.sh [--with-tests] [--standalone]"
+    echo "build.sh [--with-tests] [--standalone] [--build-base PATH]"
     echo ""
     echo "Options:"
     echo "--with-tests - build with tests."
     echo "--standalone - standalone version"
+    echo "--build-base PATH - optional colcon build base directory."
 }
 
 if [ -z "${ROS_DISTRO:-}" ]; then
@@ -25,6 +27,7 @@ TESTS=OFF
 MSG="Build started."
 STANDALONE=OFF
 PARALLEL_WORKERS="${ROS2CS_PARALLEL_WORKERS:-}"
+BUILD_BASE="${ROS2CS_BUILD_BASE:-}"
 
 # Worker count is a throughput policy; build correctness must not depend on a specific value.
 if [ -z "$PARALLEL_WORKERS" ]; then
@@ -38,7 +41,7 @@ if [ -z "$PARALLEL_WORKERS" ]; then
 fi
 
 case "$PARALLEL_WORKERS" in
-  ''|*[!0-9]*)
+  *[!0-9]*)
     echo "ROS2CS_PARALLEL_WORKERS must be a positive integer"
     exit 1
     ;;
@@ -53,6 +56,8 @@ COMPILER_LAUNCHER="${ROS2CS_COMPILER_LAUNCHER:-}"
 # Compiler launcher use is best-effort acceleration and must not be required for a correct build.
 if [ -z "$COMPILER_LAUNCHER" ] && command -v ccache >/dev/null 2>&1; then
   COMPILER_LAUNCHER="ccache"
+elif [ -z "$COMPILER_LAUNCHER" ] && command -v sccache >/dev/null 2>&1; then
+  COMPILER_LAUNCHER="sccache"
 fi
 
 while [[ $# -gt 0 ]]; do
@@ -67,6 +72,15 @@ while [[ $# -gt 0 ]]; do
       STANDALONE=ON
       MSG="$MSG (standalone)"
       shift # past argument
+      ;;
+    -b|--build-base)
+      if [ $# -lt 2 ] || [ -z "$2" ]; then
+        echo "--build-base requires a non-empty path"
+        display_usage
+        exit 1
+      fi
+      BUILD_BASE="$2"
+      shift 2
       ;;
     -h|--help)
       display_usage
@@ -95,10 +109,16 @@ if [ -n "$COMPILER_LAUNCHER" ]; then
   MSG="$MSG (compiler launcher: $COMPILER_LAUNCHER)"
 fi
 
+COLCON_ARGS=(build)
+if [ -n "$BUILD_BASE" ]; then
+  COLCON_ARGS+=(--build-base "$BUILD_BASE")
+  MSG="$MSG (build base: $BUILD_BASE)"
+fi
+
 MSG="$MSG (workers: $PARALLEL_WORKERS)"
 
 echo "$MSG"
-colcon build \
+colcon "${COLCON_ARGS[@]}" \
 --parallel-workers "$PARALLEL_WORKERS" \
 --merge-install \
 --event-handlers console_direct+ \

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
 display_usage() {
     echo "Usage: "
@@ -9,7 +10,7 @@ display_usage() {
     echo "--standalone - standalone version"
 }
 
-if [ -z "${ROS_DISTRO}" ]; then
+if [ -z "${ROS_DISTRO:-}" ]; then
     echo "Source your ros2 distro first (foxy, galactic, humble, jazzy or rolling are supported)"
     exit 1
 fi
@@ -34,15 +35,16 @@ while [[ $# -gt 0 ]]; do
     -h|--help)
       display_usage
       exit 0
-      shift # past argument
       ;;
     *)    # unknown option
-      shift # past argument
+      echo "Unknown option: $1"
+      display_usage
+      exit 1
       ;;
   esac
 done
 
-echo $MSG
+echo "$MSG"
 colcon build \
 --merge-install \
 --event-handlers console_direct+ \

--- a/get_repos.ps1
+++ b/get_repos.ps1
@@ -1,6 +1,11 @@
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
+# Modifications Copyright (c) 2026 Jianbin Liu.
+#
+# Modifications by Jianbin Liu:
+# - Added fail-fast validation for ROS_DISTRO, repository files, and custom message imports.
+
 $scriptPath = split-path -parent $MyInvocation.MyCommand.Definition
 
 if (([string]::IsNullOrEmpty($Env:ROS_DISTRO)))

--- a/get_repos.ps1
+++ b/get_repos.ps1
@@ -1,22 +1,56 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
 $scriptPath = split-path -parent $MyInvocation.MyCommand.Definition
 
 if (([string]::IsNullOrEmpty($Env:ROS_DISTRO)))
 {
     Write-Host "Can't detect ROS2 version. Source your ros2 distro first." -ForegroundColor Red
-    exit
+    exit 1
+}
+
+if ($Env:ROS_DISTRO -notmatch '^[a-z][a-z0-9_]*$')
+{
+    Write-Host "Invalid ROS_DISTRO value: '$Env:ROS_DISTRO'." -ForegroundColor Red
+    exit 1
+}
+
+$getCustomMessages = $false
+foreach ($arg in $args)
+{
+    switch ($arg)
+    {
+        "--get-custom-messages" { $getCustomMessages = $true }
+        default
+        {
+            Write-Host "Unknown option: '$arg'." -ForegroundColor Red
+            exit 1
+        }
+    }
 }
 
 $src_path = Join-Path -Path $scriptPath -ChildPath "\src"
 $repos_file = Join-Path -Path $scriptPath -ChildPath "\ros2_$Env:ROS_DISTRO.repos"
 $custom_repos_file = Join-Path -Path $scriptPath -ChildPath "\custom_messages.repos"
-$repos_file = Resolve-Path -Path $repos_file
 if (Test-Path -Path $repos_file) {
+    $repos_file = Resolve-Path -Path $repos_file
     Write-Host "Detected ROS2 $Env:ROS_DISTRO. Getting required repos from $repos_file" -ForegroundColor Green
     vcs import --input $repos_file $src_path
-    if ($args[0] -eq "--get-custom-messages") {
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+    if ($getCustomMessages) {
+        if (-Not (Test-Path -Path $custom_repos_file)) {
+            Write-Host "Can't find custom repos file: '$custom_repos_file'." -ForegroundColor Red
+            exit 1
+        }
         Write-Host "Getting custom messages from $custom_repos_file" -ForegroundColor Green
         vcs import --input $custom_repos_file $src_path
+        if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+        }
     }
 } else {
-    Write-Host "Can't find repos file : '$src_path' doesn't exist." -ForegroundColor Red
+    Write-Host "Can't find repos file: '$repos_file'." -ForegroundColor Red
+    exit 1
 }

--- a/get_repos.sh
+++ b/get_repos.sh
@@ -1,14 +1,35 @@
-#! /bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
-if [ -z "${ROS_DISTRO}" ]; then
+if [ -z "${ROS_DISTRO:-}" ]; then
     echo "Can't detect ROS2 version. Source your ros2 distro first."
     exit 1
 fi
 
-echo "Detected ROS2 ${ROS_DISTRO}. Getting required repos from 'ros2_"${ROS_DISTRO}".repos'"
-vcs import src < ros2_"${ROS_DISTRO}".repos
+if [[ ! "$ROS_DISTRO" =~ ^[a-z][a-z0-9_]*$ ]]; then
+    echo "Invalid ROS_DISTRO value: '$ROS_DISTRO'."
+    exit 1
+fi
 
-if [ "$1" = "--get-custom-messages" ]; then
+if [[ $# -gt 1 || ( $# -eq 1 && "$1" != "--get-custom-messages" ) ]]; then
+    echo "Unknown option: ${1:-}"
+    exit 1
+fi
+
+repos_file="ros2_${ROS_DISTRO}.repos"
+if [[ ! -f "$repos_file" ]]; then
+    echo "Can't find repos file: '$repos_file'."
+    exit 1
+fi
+
+echo "Detected ROS2 ${ROS_DISTRO}. Getting required repos from '$repos_file'"
+vcs import src < "$repos_file"
+
+if [ "${1:-}" = "--get-custom-messages" ]; then
+    if [[ ! -f "custom_messages.repos" ]]; then
+        echo "Can't find custom repos file: 'custom_messages.repos'."
+        exit 1
+    fi
     echo -e "\nGetting custom messages from 'custom_messages.repos'."
-    vcs import src < custom_messages.repos
+    vcs import src < "custom_messages.repos"
 fi

--- a/get_repos.sh
+++ b/get_repos.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Modifications Copyright (c) 2026 Jianbin Liu.
+#
+# Modifications by Jianbin Liu:
+# - Added fail-fast validation for ROS_DISTRO, repository files, and custom message imports.
+
 set -euo pipefail
 
 if [ -z "${ROS_DISTRO:-}" ]; then

--- a/get_repos.sh
+++ b/get_repos.sh
@@ -6,6 +6,13 @@
 
 set -euo pipefail
 
+SCRIPT_SOURCE="${BASH_SOURCE[0]}"
+case "$SCRIPT_SOURCE" in
+    */*) SCRIPT_DIR="${SCRIPT_SOURCE%/*}" ;;
+    *) SCRIPT_DIR="." ;;
+esac
+SCRIPT_DIR="$(cd "$SCRIPT_DIR" && pwd)"
+
 if [ -z "${ROS_DISTRO:-}" ]; then
     echo "Can't detect ROS2 version. Source your ros2 distro first."
     exit 1
@@ -16,25 +23,35 @@ if [[ ! "$ROS_DISTRO" =~ ^[a-z][a-z0-9_]*$ ]]; then
     exit 1
 fi
 
-if [[ $# -gt 1 || ( $# -eq 1 && "$1" != "--get-custom-messages" ) ]]; then
-    echo "Unknown option: ${1:-}"
-    exit 1
-fi
+GET_CUSTOM_MESSAGES=0
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --get-custom-messages)
+            GET_CUSTOM_MESSAGES=1
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
 
-repos_file="ros2_${ROS_DISTRO}.repos"
+repos_file="${SCRIPT_DIR}/ros2_${ROS_DISTRO}.repos"
 if [[ ! -f "$repos_file" ]]; then
     echo "Can't find repos file: '$repos_file'."
     exit 1
 fi
 
 echo "Detected ROS2 ${ROS_DISTRO}. Getting required repos from '$repos_file'"
-vcs import src < "$repos_file"
+vcs import "${SCRIPT_DIR}/src" < "$repos_file"
 
-if [ "${1:-}" = "--get-custom-messages" ]; then
-    if [[ ! -f "custom_messages.repos" ]]; then
-        echo "Can't find custom repos file: 'custom_messages.repos'."
+if [ "$GET_CUSTOM_MESSAGES" -eq 1 ]; then
+    custom_repos_file="${SCRIPT_DIR}/custom_messages.repos"
+    if [[ ! -f "$custom_repos_file" ]]; then
+        echo "Can't find custom repos file: '$custom_repos_file'."
         exit 1
     fi
-    echo -e "\nGetting custom messages from 'custom_messages.repos'."
-    vcs import src < "custom_messages.repos"
+    echo -e "\nGetting custom messages from '$custom_repos_file'."
+    vcs import "${SCRIPT_DIR}/src" < "$custom_repos_file"
 fi

--- a/ros2_foxy.repos
+++ b/ros2_foxy.repos
@@ -1,3 +1,6 @@
+# Legacy distro file - not maintained on JianbinLiu-CFLab/main.
+# Use ros2_jazzy.repos for the active maintenance line.
+
 repositories:
   ros2/rosidl_defaults:
     type: git
@@ -10,6 +13,10 @@ repositories:
   ros2/unique_identifier_msgs:
     type: git
     url: https://github.com/ros2/unique_identifier_msgs.git
+    version: foxy
+  ros2/example_interfaces:
+    type: git
+    url: https://github.com/ros2/example_interfaces.git
     version: foxy
   ros2/rcl_interfaces:
     type: git
@@ -30,4 +37,5 @@ repositories:
   external/build_tools/ament_cmake_export_assemblies:
     type: git
     url: https://github.com/RobotecAI/ament_cmake_export_assemblies
+    # Historical upstream tracking branch retained for this legacy distro file.
     version: master

--- a/ros2_galactic.repos
+++ b/ros2_galactic.repos
@@ -1,3 +1,6 @@
+# Legacy distro file - not maintained on JianbinLiu-CFLab/main.
+# Use ros2_jazzy.repos for the active maintenance line.
+
 repositories:
   ros2/rosidl_defaults:
     type: git
@@ -34,4 +37,5 @@ repositories:
   external/build_tools/ament_cmake_export_assemblies:
     type: git
     url: https://github.com/RobotecAI/ament_cmake_export_assemblies
+    # Historical upstream tracking branch retained for this legacy distro file.
     version: master

--- a/ros2_humble.repos
+++ b/ros2_humble.repos
@@ -1,3 +1,6 @@
+# Legacy distro file - not maintained on JianbinLiu-CFLab/main.
+# Use ros2_jazzy.repos for the active maintenance line.
+
 repositories:
   ros2/rosidl_defaults:
     type: git
@@ -34,4 +37,5 @@ repositories:
   external/build_tools/ament_cmake_export_assemblies:
     type: git
     url: https://github.com/RobotecAI/ament_cmake_export_assemblies
+    # Historical upstream tracking branch retained for this legacy distro file.
     version: master

--- a/ros2_jazzy.repos
+++ b/ros2_jazzy.repos
@@ -1,0 +1,41 @@
+repositories:
+  ros2/rosidl_defaults:
+    type: git
+    url: https://github.com/ros2/rosidl_defaults.git
+    version: jazzy
+  ros2/rosidl_core:
+    type: git
+    url: https://github.com/ros2/rosidl_core.git
+    version: jazzy
+  ros2/common_interfaces:
+    type: git
+    url: https://github.com/ros2/common_interfaces.git
+    version: jazzy
+  ros2/example_interfaces:
+    type: git
+    url: https://github.com/ros2/example_interfaces.git
+    version: jazzy
+  ros2/unique_identifier_msgs:
+    type: git
+    url: https://github.com/ros2/unique_identifier_msgs.git
+    version: jazzy
+  ros2/rcl_interfaces:
+    type: git
+    url: https://github.com/ros2/rcl_interfaces.git
+    version: jazzy
+  ros2/geometry2:
+    type: git
+    url: https://github.com/ros2/geometry2.git
+    version: jazzy
+  ros2/test_interface_files:
+    type: git
+    url: https://github.com/ros2/test_interface_files.git
+    version: jazzy
+  external/build_tools/dotnet_cmake_module:
+    type: git
+    url: https://github.com/RobotecAI/dotnet_cmake_module
+    version: 1.1.0
+  external/build_tools/ament_cmake_export_assemblies:
+    type: git
+    url: https://github.com/RobotecAI/ament_cmake_export_assemblies
+    version: master

--- a/ros2_jazzy.repos
+++ b/ros2_jazzy.repos
@@ -3,6 +3,7 @@
 # Modifications by Jianbin Liu:
 # - Point dotnet_cmake_module to the JianbinLiu-CFLab mainline with the Jazzy .NET test registration fix.
 # - Point rosidl_python to the JianbinLiu-CFLab Jazzy fork with shortened Python extension CMake targets.
+# - Pin dotnet_cmake_module to a verified commit for reproducible Jazzy builds.
 
 repositories:
   ros2/rosidl_defaults:
@@ -48,7 +49,7 @@ repositories:
   external/build_tools/dotnet_cmake_module:
     type: git
     url: https://github.com/JianbinLiu-CFLab/dotnet_cmake_module.git
-    version: main
+    version: c884bbb5ae6ec35c69aa7c5375401696f08750f3
   external/build_tools/ament_cmake_export_assemblies:
     type: git
     url: https://github.com/RobotecAI/ament_cmake_export_assemblies

--- a/ros2_jazzy.repos
+++ b/ros2_jazzy.repos
@@ -1,7 +1,7 @@
 # Modifications Copyright (c) 2026 Jianbin Liu.
 #
 # Modifications by Jianbin Liu:
-# - Pin dotnet_cmake_module to a fork commit that fixes Jazzy .NET test registration.
+# - Point dotnet_cmake_module to the JianbinLiu-CFLab mainline with the Jazzy .NET test registration fix.
 
 repositories:
   ros2/rosidl_defaults:
@@ -43,7 +43,7 @@ repositories:
   external/build_tools/dotnet_cmake_module:
     type: git
     url: https://github.com/JianbinLiu-CFLab/dotnet_cmake_module.git
-    version: c884bbb5ae6ec35c69aa7c5375401696f08750f3
+    version: main
   external/build_tools/ament_cmake_export_assemblies:
     type: git
     url: https://github.com/RobotecAI/ament_cmake_export_assemblies

--- a/ros2_jazzy.repos
+++ b/ros2_jazzy.repos
@@ -7,6 +7,10 @@ repositories:
     type: git
     url: https://github.com/ros2/rosidl_core.git
     version: jazzy
+  ros2/rosidl_dynamic_typesupport_fastrtps:
+    type: git
+    url: https://github.com/ros2/rosidl_dynamic_typesupport_fastrtps.git
+    version: jazzy
   ros2/common_interfaces:
     type: git
     url: https://github.com/ros2/common_interfaces.git

--- a/ros2_jazzy.repos
+++ b/ros2_jazzy.repos
@@ -1,3 +1,8 @@
+# Modifications Copyright (c) 2026 Jianbin Liu.
+#
+# Modifications by Jianbin Liu:
+# - Pin dotnet_cmake_module to a fork commit that fixes Jazzy .NET test registration.
+
 repositories:
   ros2/rosidl_defaults:
     type: git
@@ -37,8 +42,8 @@ repositories:
     version: jazzy
   external/build_tools/dotnet_cmake_module:
     type: git
-    url: https://github.com/RobotecAI/dotnet_cmake_module
-    version: 1.1.0
+    url: https://github.com/JianbinLiu-CFLab/dotnet_cmake_module.git
+    version: c884bbb5ae6ec35c69aa7c5375401696f08750f3
   external/build_tools/ament_cmake_export_assemblies:
     type: git
     url: https://github.com/RobotecAI/ament_cmake_export_assemblies

--- a/ros2_jazzy.repos
+++ b/ros2_jazzy.repos
@@ -4,8 +4,10 @@
 # - Point dotnet_cmake_module to the JianbinLiu-CFLab mainline with the Jazzy .NET test registration fix.
 # - Point rosidl_python to the JianbinLiu-CFLab Jazzy fork with shortened Python extension CMake targets.
 # - Pin dotnet_cmake_module to a verified commit for reproducible Jazzy builds.
+# - Pin ament_cmake_export_assemblies to a verified commit for reproducible Jazzy builds.
 
 repositories:
+  # Upstream Jazzy branches. These track the ROS 2 Jazzy maintenance line.
   ros2/rosidl_defaults:
     type: git
     url: https://github.com/ros2/rosidl_defaults.git
@@ -46,6 +48,7 @@ repositories:
     type: git
     url: https://github.com/ros2/test_interface_files.git
     version: jazzy
+  # Build-tool inputs pinned to verified commits.
   external/build_tools/dotnet_cmake_module:
     type: git
     url: https://github.com/JianbinLiu-CFLab/dotnet_cmake_module.git
@@ -53,4 +56,4 @@ repositories:
   external/build_tools/ament_cmake_export_assemblies:
     type: git
     url: https://github.com/RobotecAI/ament_cmake_export_assemblies
-    version: master
+    version: 5a7411c1744d266717da9f292053165102b442c3

--- a/ros2_jazzy.repos
+++ b/ros2_jazzy.repos
@@ -2,6 +2,7 @@
 #
 # Modifications by Jianbin Liu:
 # - Point dotnet_cmake_module to the JianbinLiu-CFLab mainline with the Jazzy .NET test registration fix.
+# - Point rosidl_python to the JianbinLiu-CFLab Jazzy fork with shortened Python extension CMake targets.
 
 repositories:
   ros2/rosidl_defaults:
@@ -16,6 +17,10 @@ repositories:
     type: git
     url: https://github.com/ros2/rosidl_dynamic_typesupport_fastrtps.git
     version: jazzy
+  ros2/rosidl_python:
+    type: git
+    url: https://github.com/JianbinLiu-CFLab/rosidl_python.git
+    version: d10c7d9ab585c66090bbc6a401f9d490ce78fdc4
   ros2/common_interfaces:
     type: git
     url: https://github.com/ros2/common_interfaces.git

--- a/ros2_rolling.repos
+++ b/ros2_rolling.repos
@@ -1,3 +1,7 @@
+# Unmaintained on JianbinLiu-CFLab/main.
+# This file tracks upstream Rolling/HEAD-style branches and is not verified for
+# the active Jazzy maintenance line.
+
 repositories:
   ros2/rosidl_defaults:
     type: git
@@ -18,6 +22,7 @@ repositories:
   ros2/geometry2:
     type: git
     url: https://github.com/ros2/geometry2.git
+    # geometry2 uses the upstream ros2 branch for Rolling.
     version: ros2
   ros2/test_interface_files:
     type: git
@@ -30,4 +35,5 @@ repositories:
   external/build_tools/ament_cmake_export_assemblies:
     type: git
     url: https://github.com/RobotecAI/ament_cmake_export_assemblies
+    # Historical upstream tracking branch retained for this unmaintained file.
     version: master

--- a/src/ros2cs/ros2cs_common/Benchmark.cs
+++ b/src/ros2cs/ros2cs_common/Benchmark.cs
@@ -2,9 +2,11 @@
 //
 // Modifications by Jianbin Liu:
 // - Kept benchmark disposal behavior explicit while auditing ros2cs common helpers.
+// - Made benchmark disposal idempotent under concurrent callers.
 
 using System;
 using System.Diagnostics;
+using System.Threading;
 
 namespace ROS2
 {
@@ -21,8 +23,8 @@ namespace ROS2
     private readonly Stopwatch timer = new Stopwatch();
     private readonly string benchmarkName;
 
-    public bool IsDisposed { get { return disposed; } }
-    private bool disposed = false;
+    public bool IsDisposed { get { return disposed != 0; } }
+    private int disposed = 0;
 
     public Benchmark(string benchmarkName)
     {
@@ -32,11 +34,10 @@ namespace ROS2
 
     public void Dispose()
     {
-      if (!disposed)
+      if (Interlocked.Exchange(ref disposed, 1) == 0)
       {
         timer.Stop();
         Ros2csLogger.GetInstance().LogDebug($"{benchmarkName} {timer.ElapsedTicks} ticks ({timer.ElapsedMilliseconds} ms)");
-        disposed = true;
       }
     }
   }

--- a/src/ros2cs/ros2cs_common/Benchmark.cs
+++ b/src/ros2cs/ros2cs_common/Benchmark.cs
@@ -30,7 +30,7 @@ namespace ROS2
       if (!disposed)
       {
         timer.Stop();
-        Console.WriteLine($"{benchmarkName} {timer.ElapsedTicks} ticks ({timer.ElapsedMilliseconds} ms)");
+        Ros2csLogger.GetInstance().LogDebug($"{benchmarkName} {timer.ElapsedTicks} ticks ({timer.ElapsedMilliseconds} ms)");
         disposed = true;
       }
     }

--- a/src/ros2cs/ros2cs_common/Benchmark.cs
+++ b/src/ros2cs/ros2cs_common/Benchmark.cs
@@ -1,3 +1,8 @@
+// Modifications Copyright (c) 2026 Jianbin Liu.
+//
+// Modifications by Jianbin Liu:
+// - Kept benchmark disposal behavior explicit while auditing ros2cs common helpers.
+
 using System;
 using System.Diagnostics;
 

--- a/src/ros2cs/ros2cs_common/CMakeLists.txt
+++ b/src/ros2cs/ros2cs_common/CMakeLists.txt
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Modifications Copyright (c) 2026 Jianbin Liu.
+#
+# Modifications by Jianbin Liu:
+# - Audited common library build metadata during Jazzy/.NET maintenance.
+
 cmake_minimum_required(VERSION 3.5)
 
 project(ros2cs_common)
@@ -51,7 +56,3 @@ if(BUILD_TESTING)
 endif()
 
 ament_package()
-# Modifications Copyright (c) 2026 Jianbin Liu.
-#
-# Modifications by Jianbin Liu:
-# - Audited common library build metadata during Jazzy/.NET maintenance.

--- a/src/ros2cs/ros2cs_common/CMakeLists.txt
+++ b/src/ros2cs/ros2cs_common/CMakeLists.txt
@@ -39,8 +39,6 @@ set(CS_INTERFACES
 add_dotnet_library(${PROJECT_NAME}
 SOURCES
   ${CS_INTERFACES}
-  INCLUDE_DLLS
-  ${_assembly_deps_dll}
 )
 
 install_dotnet(${PROJECT_NAME} DESTINATION lib/dotnet)

--- a/src/ros2cs/ros2cs_common/CMakeLists.txt
+++ b/src/ros2cs/ros2cs_common/CMakeLists.txt
@@ -51,3 +51,7 @@ if(BUILD_TESTING)
 endif()
 
 ament_package()
+# Modifications Copyright (c) 2026 Jianbin Liu.
+#
+# Modifications by Jianbin Liu:
+# - Audited common library build metadata during Jazzy/.NET maintenance.

--- a/src/ros2cs/ros2cs_common/DllLoadUtils.cs
+++ b/src/ros2cs/ros2cs_common/DllLoadUtils.cs
@@ -18,6 +18,7 @@
 // - Added disposable ownership for native library handles.
 // - Hardened platform detection and native unload guards.
 // - Reworked Linux preload tracking to avoid stale handles.
+// - Serialized native library handle disposal and symbol lookup diagnostics.
 
 // Based on http://dimitry-i.blogspot.com.es/2013/01/mononet-how-to-dynamically-load-native.html
 
@@ -71,26 +72,6 @@ namespace ROS2
     [DllImport ("api-ms-win-core-libraryloader-l1-2-0.dll", EntryPoint = "FreeLibrary", SetLastError = true, ExactSpelling = true)]
     private static extern int FreeLibraryUWP (IntPtr handle);
 
-    [DllImport ("kernel32.dll", SetLastError = true)]
-    private static extern IntPtr LoadLibrary (string fileName);
-
-    [DllImport ("kernel32.dll", EntryPoint = "FreeLibrary", SetLastError = true)]
-    private static extern int FreeLibraryDesktop (IntPtr handle);
-
-    [DllImport ("libdl.so.2", EntryPoint = "dlopen")]
-    private static extern IntPtr dlopen_unix (String fileName, int flags);
-
-    [DllImport ("libdl.so.2", EntryPoint = "dlclose")]
-    private static extern int dlclose_unix (IntPtr handle);
-
-    [DllImport ("libdl.dylib", EntryPoint = "dlopen")]
-    private static extern IntPtr dlopen_macosx (String fileName, int flags);
-
-    [DllImport ("libdl.dylib", EntryPoint = "dlclose")]
-    private static extern int dlclose_macosx (IntPtr handle);
-
-    const int RTLD_NOW = 2;
-
     public static DllLoadUtils GetDllLoadUtils () {
       switch (CheckPlatform ()) {
         case Platform.Unix:
@@ -125,36 +106,6 @@ namespace ROS2
       }
     }
 
-    private static bool IsWindowsDesktop () {
-      try {
-        IntPtr ptr = LoadLibrary ("kernel32.dll");
-        FreeLibraryDesktop (ptr);
-        return true;
-      } catch (TypeLoadException) {
-        return false;
-      }
-    }
-
-    private static bool IsUnix () {
-      try {
-        IntPtr ptr = dlopen_unix ("libdl.so.2", RTLD_NOW);
-        dlclose_unix (ptr);
-        return true;
-      } catch (TypeLoadException) {
-        return false;
-      }
-    }
-
-    private static bool IsMacOSX () {
-      try {
-        IntPtr ptr = dlopen_macosx ("libdl.dylib", RTLD_NOW);
-        dlclose_macosx (ptr);
-        return true;
-      } catch (TypeLoadException) {
-        return false;
-      }
-    }
-
     private static Platform CheckPlatform () {
       // Prefer RuntimeInformation for coarse OS detection before probing platform-specific loaders.
       if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -185,6 +136,7 @@ namespace ROS2
   public sealed class NativeLibraryHandle : IDisposable
   {
     private readonly DllLoadUtils dllLoadUtils;
+    private readonly object mutex = new object();
     private IntPtr handle;
     private bool disposed;
 
@@ -199,11 +151,14 @@ namespace ROS2
     {
       get
       {
-        if (disposed)
+        lock (mutex)
         {
-          throw new ObjectDisposedException(nameof(NativeLibraryHandle));
+          if (disposed)
+          {
+            throw new ObjectDisposedException(nameof(NativeLibraryHandle));
+          }
+          return handle;
         }
-        return handle;
       }
     }
 
@@ -244,25 +199,28 @@ namespace ROS2
     /// <summary>Shared dispose path used by explicit disposal and the finalizer.</summary>
     private void Dispose(bool disposing)
     {
-      if (disposed)
+      lock (mutex)
       {
-        return;
-      }
-
-      try
-      {
-        if (handle != IntPtr.Zero)
+        if (disposed)
         {
-          dllLoadUtils.FreeLibrary(handle);
+          return;
         }
-      }
-      catch
-      {
-      }
-      finally
-      {
-        handle = IntPtr.Zero;
-        disposed = true;
+
+        try
+        {
+          if (handle != IntPtr.Zero)
+          {
+            dllLoadUtils.FreeLibrary(handle);
+          }
+        }
+        catch
+        {
+        }
+        finally
+        {
+          handle = IntPtr.Zero;
+          disposed = true;
+        }
       }
     }
   }
@@ -285,7 +243,11 @@ namespace ROS2
     }
 
     IntPtr DllLoadUtils.GetProcAddress (IntPtr dllHandle, string name) {
-      return GetProcAddress (dllHandle, name);
+      IntPtr ptr = GetProcAddress (dllHandle, name);
+      if (ptr == IntPtr.Zero) {
+        throw new EntryPointNotFoundException(name);
+      }
+      return ptr;
     }
 
     IntPtr DllLoadUtils.LoadLibrary (string fileName) {
@@ -325,7 +287,11 @@ namespace ROS2
     }
 
     IntPtr DllLoadUtils.GetProcAddress (IntPtr dllHandle, string name) {
-      return GetProcAddress (dllHandle, name);
+      IntPtr ptr = GetProcAddress (dllHandle, name);
+      if (ptr == IntPtr.Zero) {
+        throw new EntryPointNotFoundException(name);
+      }
+      return ptr;
     }
 
     IntPtr DllLoadUtils.LoadLibrary (string fileName) {
@@ -362,7 +328,6 @@ namespace ROS2
     private static extern IntPtr dlerror ();
 
     const int RTLD_NOW = 0x00002;
-    const int RTLD_DEEPBIND = 0x00008;
 
     //TODO (adamdbrw) Somewhat hacky solution to open (and dereference) the problematic library
     //that otherwise causes crashes in Unity Editor.
@@ -413,7 +378,7 @@ namespace ROS2
       var res = dlsym (dllHandle, name);
       var errPtr = dlerror ();
       if (errPtr != IntPtr.Zero) {
-        throw new Exception ("dlsym: " + Marshal.PtrToStringAnsi (errPtr));
+        throw new EntryPointNotFoundException (name + ": " + Marshal.PtrToStringAnsi (errPtr));
       }
       return res;
     }
@@ -433,6 +398,11 @@ namespace ROS2
         }
       }      
       if (ptr == IntPtr.Zero) {
+        var errPtr = dlerror ();
+        string detail = Marshal.PtrToStringAnsi (errPtr);
+        if (!String.IsNullOrEmpty(detail)) {
+          throw new UnsatisfiedLinkError(dlopenSearchString + ": " + detail);
+        }
         throw new UnsatisfiedLinkError(dlopenSearchString);
       }
       Ros2csLogger.GetInstance().LogDebug("Loaded library: " + dlopenSearchString);
@@ -485,7 +455,7 @@ namespace ROS2
       var res = dlsym (dllHandle, name);
       var errPtr = dlerror ();
       if (errPtr != IntPtr.Zero) {
-        throw new Exception ("dlsym: " + Marshal.PtrToStringAnsi (errPtr));
+        throw new EntryPointNotFoundException (name + ": " + Marshal.PtrToStringAnsi (errPtr));
       }
       return res;
     }

--- a/src/ros2cs/ros2cs_common/DllLoadUtils.cs
+++ b/src/ros2cs/ros2cs_common/DllLoadUtils.cs
@@ -24,6 +24,7 @@
 using System;
 using System.Runtime;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace ROS2
 {
@@ -31,6 +32,28 @@ namespace ROS2
     public static bool preloadLibrary = false;
     public static string preloadLibraryName = "";
     public static string absolutePath = "";
+
+    internal struct Snapshot
+    {
+      internal bool PreloadLibrary;
+      internal string PreloadLibraryName;
+      internal string AbsolutePath;
+
+      internal Snapshot(bool preloadLibrary, string preloadLibraryName, string absolutePath)
+      {
+        PreloadLibrary = preloadLibrary;
+        PreloadLibraryName = preloadLibraryName ?? "";
+        AbsolutePath = absolutePath ?? "";
+      }
+    }
+
+    internal static Snapshot GetSnapshot()
+    {
+      return new Snapshot(
+        Volatile.Read(ref preloadLibrary),
+        Volatile.Read(ref preloadLibraryName),
+        Volatile.Read(ref absolutePath));
+    }
   }
 
   public enum Platform {
@@ -347,23 +370,35 @@ namespace ROS2
     private static string preloadedLibraryKey = "";
     // Retains ownership of the preloaded dependency for the lifetime of the Unix loader.
     private static NativeLibraryHandle preloadedLibraryHandle = null;
+    private static readonly object preloadMutex = new object();
     /// <summary>Preload a configured dependency once per absolute path/name pair.</summary>
-    void CheckPreloadLibraries()
+    void CheckPreloadLibraries(GlobalVariables.Snapshot settings)
     {
-        string preloadKey = GlobalVariables.absolutePath + "|" + GlobalVariables.preloadLibraryName;
-        if (preloadedLibraryKey == preloadKey || GlobalVariables.preloadLibraryName == "")
+      string preloadKey = settings.AbsolutePath + "|" + settings.PreloadLibraryName;
+      if (settings.PreloadLibraryName == "")
+      {
+        return;
+      }
+
+      lock (preloadMutex)
+      {
+        if (preloadedLibraryKey == preloadKey)
+        {
             return;
-        Ros2csLogger.GetInstance().LogDebug("Preloading " + GlobalVariables.preloadLibraryName);
-        IntPtr libPtr = Load(GlobalVariables.preloadLibraryName);
+        }
+
+        Ros2csLogger.GetInstance().LogDebug("Preloading " + settings.PreloadLibraryName);
+        IntPtr libPtr = Load(settings.PreloadLibraryName, settings.AbsolutePath);
         if (preloadedLibraryHandle != null)
         {
           preloadedLibraryHandle.Dispose();
         }
         preloadedLibraryHandle = NativeLibraryHandle.FromHandle(this, libPtr);
 
-        Ros2csLogger.GetInstance().LogDebug("Preloading " + GlobalVariables.preloadLibraryName + " successful.");
+        Ros2csLogger.GetInstance().LogDebug("Preloading " + settings.PreloadLibraryName + " successful.");
 
         preloadedLibraryKey = preloadKey;
+      }
     }
 
     public void FreeLibrary (IntPtr handle) {
@@ -383,13 +418,13 @@ namespace ROS2
       return res;
     }
 
-    private IntPtr Load(string libraryFileName) {
-      string libraryPath = GlobalVariables.absolutePath + libraryFileName;
+    private IntPtr Load(string libraryFileName, string absolutePath) {
+      string libraryPath = absolutePath + libraryFileName;
       string dlopenSearchString = libraryPath;
       Ros2csLogger.GetInstance().LogDebug("Loading lib: " + dlopenSearchString);
       IntPtr ptr = dlopen(dlopenSearchString, RTLD_NOW);
       if (ptr == IntPtr.Zero) {
-        if (!String.IsNullOrEmpty(GlobalVariables.absolutePath)) {
+        if (!String.IsNullOrEmpty(absolutePath)) {
           // Fallback - look for library in default paths
           var errPtr = dlerror ();
           Ros2csLogger.GetInstance().LogDebug("Could not find " + dlopenSearchString + ": " + Marshal.PtrToStringAnsi (errPtr) + ". Fallback to " + libraryFileName);
@@ -405,9 +440,10 @@ namespace ROS2
     }
 
     private IntPtr LoadLibraryByName(string libraryFileName) {
-      if (GlobalVariables.preloadLibrary)
-        CheckPreloadLibraries();
-      return Load(libraryFileName);
+      GlobalVariables.Snapshot settings = GlobalVariables.GetSnapshot();
+      if (settings.PreloadLibrary)
+        CheckPreloadLibraries(settings);
+      return Load(libraryFileName, settings.AbsolutePath);
     }
 
     public IntPtr LoadLibrary(string fileName) {

--- a/src/ros2cs/ros2cs_common/DllLoadUtils.cs
+++ b/src/ros2cs/ros2cs_common/DllLoadUtils.cs
@@ -1,5 +1,6 @@
 // Copyright 2019-2021 Robotec.ai
 // Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +13,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// Modifications by Jianbin Liu:
+// - Added disposable ownership for native library handles.
+// - Hardened platform detection and native unload guards.
+// - Reworked Linux preload tracking to avoid stale handles.
 
 // Based on http://dimitry-i.blogspot.com.es/2013/01/mononet-how-to-dynamically-load-native.html
 
@@ -80,10 +86,18 @@ namespace ROS2
 
     private static bool IsUWP () {
       try {
-        IntPtr ptr = LoadPackagedLibrary ("api-ms-win-core-libraryloader-l2-1-0.dll");
+        // Probe a stable system library; app containers reject this path on desktop-only runtimes.
+        IntPtr ptr = LoadPackagedLibrary ("kernel32.dll");
+        if (ptr == IntPtr.Zero) {
+          return false;
+        }
         FreeLibraryUWP (ptr);
         return true;
-      } catch (TypeLoadException) {
+      } catch (Exception e) when (
+          e is TypeLoadException ||
+          e is DllNotFoundException ||
+          e is EntryPointNotFoundException ||
+          e is BadImageFormatException) {
         return false;
       }
     }
@@ -119,26 +133,20 @@ namespace ROS2
     }
 
     private static Platform CheckPlatform () {
-          if (IsUnix())
-          {
-              return Platform.Unix;
-          }
-          else if (IsMacOSX())
-          {
-              return Platform.MacOSX;
-          }
-          else if (IsWindowsDesktop())
-          {
-              return Platform.WindowsDesktop;
-          }
-          else if (IsUWP())
-          {
-              return Platform.UWP;
-          }
-          else
-          {
-              return Platform.Unknown;
-          }
+      // Prefer RuntimeInformation for coarse OS detection before probing platform-specific loaders.
+      if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+      {
+        return IsUWP() ? Platform.UWP : Platform.WindowsDesktop;
+      }
+      if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+      {
+        return Platform.MacOSX;
+      }
+      if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+      {
+        return Platform.Unix;
+      }
+      return Platform.Unknown;
     }
   }
 
@@ -147,6 +155,93 @@ namespace ROS2
     IntPtr LoadLibraryNoSuffix (string fileName);
     void FreeLibrary (IntPtr handle);
     IntPtr GetProcAddress (IntPtr dllHandle, string name);
+  }
+
+  /// <summary>Owns a loaded native library and releases it when disposed.</summary>
+  /// <remarks>Keeps native libraries alive while delegates created from them remain reachable.</remarks>
+  public sealed class NativeLibraryHandle : IDisposable
+  {
+    private readonly DllLoadUtils dllLoadUtils;
+    private IntPtr handle;
+    private bool disposed;
+
+    private NativeLibraryHandle(DllLoadUtils dllLoadUtils, IntPtr handle)
+    {
+      this.dllLoadUtils = dllLoadUtils;
+      this.handle = handle;
+    }
+
+    /// <summary>Native library handle used for symbol resolution.</summary>
+    public IntPtr Handle
+    {
+      get
+      {
+        if (disposed)
+        {
+          throw new ObjectDisposedException(nameof(NativeLibraryHandle));
+        }
+        return handle;
+      }
+    }
+
+    /// <summary>Load a ros2cs-style native library and wrap ownership of the returned handle.</summary>
+    public static NativeLibraryHandle LoadLibrary(DllLoadUtils dllLoadUtils, string fileName)
+    {
+      return new NativeLibraryHandle(dllLoadUtils, dllLoadUtils.LoadLibrary(fileName));
+    }
+
+    /// <summary>Load a native library by its exact platform name and wrap ownership of the handle.</summary>
+    public static NativeLibraryHandle LoadLibraryNoSuffix(DllLoadUtils dllLoadUtils, string fileName)
+    {
+      return new NativeLibraryHandle(dllLoadUtils, dllLoadUtils.LoadLibraryNoSuffix(fileName));
+    }
+
+    /// <summary>Wrap an already loaded native library handle so it is released exactly once.</summary>
+    public static NativeLibraryHandle FromHandle(DllLoadUtils dllLoadUtils, IntPtr handle)
+    {
+      if (handle == IntPtr.Zero)
+      {
+        throw new ArgumentException("Native library handle cannot be zero", nameof(handle));
+      }
+      return new NativeLibraryHandle(dllLoadUtils, handle);
+    }
+
+    ~NativeLibraryHandle()
+    {
+      Dispose(false);
+    }
+
+    /// <summary>Release the native library handle.</summary>
+    public void Dispose()
+    {
+      Dispose(true);
+      GC.SuppressFinalize(this);
+    }
+
+    /// <summary>Shared dispose path used by explicit disposal and the finalizer.</summary>
+    private void Dispose(bool disposing)
+    {
+      if (disposed)
+      {
+        return;
+      }
+
+      try
+      {
+        if (handle != IntPtr.Zero)
+        {
+          dllLoadUtils.FreeLibrary(handle);
+        }
+      }
+      catch
+      {
+      }
+      finally
+      {
+        handle = IntPtr.Zero;
+        disposed = true;
+      }
+    }
   }
 
   public class DllLoadUtilsUWP : DllLoadUtils {
@@ -161,7 +256,9 @@ namespace ROS2
     private static extern IntPtr GetProcAddress (IntPtr handle, string procedureName);
 
     void DllLoadUtils.FreeLibrary (IntPtr handle) {
-      FreeLibrary (handle);
+      if (handle != IntPtr.Zero) {
+        FreeLibrary (handle);
+      }
     }
 
     IntPtr DllLoadUtils.GetProcAddress (IntPtr dllHandle, string name) {
@@ -199,7 +296,9 @@ namespace ROS2
     private static extern IntPtr GetProcAddress (IntPtr handle, string procedureName);
 
     void DllLoadUtils.FreeLibrary (IntPtr handle) {
-      FreeLibrary (handle);
+      if (handle != IntPtr.Zero) {
+        FreeLibrary (handle);
+      }
     }
 
     IntPtr DllLoadUtils.GetProcAddress (IntPtr dllHandle, string name) {
@@ -244,21 +343,33 @@ namespace ROS2
 
     //TODO (adamdbrw) Somewhat hacky solution to open (and dereference) the problematic library
     //that otherwise causes crashes in Unity Editor.
-    private static bool libPreloaded = false;
+    // Tracks the exact preload target so path/name changes refresh the native handle.
+    private static string preloadedLibraryKey = "";
+    // Retains ownership of the preloaded dependency for the lifetime of the Unix loader.
+    private static NativeLibraryHandle preloadedLibraryHandle = null;
+    /// <summary>Preload a configured dependency once per absolute path/name pair.</summary>
     void CheckPreloadLibraries()
     {
-        if (libPreloaded || GlobalVariables.preloadLibraryName == "")
+        string preloadKey = GlobalVariables.absolutePath + "|" + GlobalVariables.preloadLibraryName;
+        if (preloadedLibraryKey == preloadKey || GlobalVariables.preloadLibraryName == "")
             return;
         Ros2csLogger.GetInstance().LogDebug("Preloading " + GlobalVariables.preloadLibraryName);
         IntPtr libPtr = Load(GlobalVariables.preloadLibraryName);
+        if (preloadedLibraryHandle != null)
+        {
+          preloadedLibraryHandle.Dispose();
+        }
+        preloadedLibraryHandle = NativeLibraryHandle.FromHandle(this, libPtr);
 
         Ros2csLogger.GetInstance().LogDebug("Preloading " + GlobalVariables.preloadLibraryName + " successful.");
 
-        libPreloaded = true;
+        preloadedLibraryKey = preloadKey;
     }
 
     public void FreeLibrary (IntPtr handle) {
-      dlclose (handle);
+      if (handle != IntPtr.Zero) {
+        dlclose (handle);
+      }
     }
 
     public IntPtr GetProcAddress (IntPtr dllHandle, string name) {
@@ -327,7 +438,9 @@ namespace ROS2
     const int RTLD_NOW = 2;
 
     public void FreeLibrary (IntPtr handle) {
-      dlclose (handle);
+      if (handle != IntPtr.Zero) {
+        dlclose (handle);
+      }
     }
 
     public IntPtr GetProcAddress (IntPtr dllHandle, string name) {

--- a/src/ros2cs/ros2cs_common/DllLoadUtils.cs
+++ b/src/ros2cs/ros2cs_common/DllLoadUtils.cs
@@ -19,6 +19,7 @@
 // - Hardened platform detection and native unload guards.
 // - Reworked Linux preload tracking to avoid stale handles.
 // - Serialized native library handle disposal and symbol lookup diagnostics.
+// - Made native loader settings an atomic snapshot and applied them on macOS.
 
 // Based on http://dimitry-i.blogspot.com.es/2013/01/mononet-how-to-dynamically-load-native.html
 
@@ -30,15 +31,46 @@ using System.Threading;
 namespace ROS2
 {
   public class GlobalVariables {
-    public static bool preloadLibrary = false;
-    public static string preloadLibraryName = "";
-    public static string absolutePath = "";
+    private static Snapshot settings = new Snapshot(false, "", "");
 
-    internal struct Snapshot
+    /// <summary>Whether a native dependency should be preloaded before loading ros2cs libraries.</summary>
+    public static bool preloadLibrary
     {
-      internal bool PreloadLibrary;
-      internal string PreloadLibraryName;
-      internal string AbsolutePath;
+      get { return GetSnapshot().PreloadLibrary; }
+      set
+      {
+        Snapshot current = GetSnapshot();
+        SetSnapshot(new Snapshot(value, current.PreloadLibraryName, current.AbsolutePath));
+      }
+    }
+
+    /// <summary>Native dependency name used when <see cref="preloadLibrary"/> is enabled.</summary>
+    public static string preloadLibraryName
+    {
+      get { return GetSnapshot().PreloadLibraryName; }
+      set
+      {
+        Snapshot current = GetSnapshot();
+        SetSnapshot(new Snapshot(current.PreloadLibrary, value, current.AbsolutePath));
+      }
+    }
+
+    /// <summary>Optional absolute search path prepended before falling back to platform defaults.</summary>
+    public static string absolutePath
+    {
+      get { return GetSnapshot().AbsolutePath; }
+      set
+      {
+        Snapshot current = GetSnapshot();
+        SetSnapshot(new Snapshot(current.PreloadLibrary, current.PreloadLibraryName, value));
+      }
+    }
+
+    internal sealed class Snapshot
+    {
+      internal readonly bool PreloadLibrary;
+      internal readonly string PreloadLibraryName;
+      internal readonly string AbsolutePath;
 
       internal Snapshot(bool preloadLibrary, string preloadLibraryName, string absolutePath)
       {
@@ -50,10 +82,18 @@ namespace ROS2
 
     internal static Snapshot GetSnapshot()
     {
-      return new Snapshot(
-        Volatile.Read(ref preloadLibrary),
-        Volatile.Read(ref preloadLibraryName),
-        Volatile.Read(ref absolutePath));
+      return Volatile.Read(ref settings);
+    }
+
+    /// <summary>Atomically replace all native loader settings.</summary>
+    public static void SetLoaderSettings(bool preloadLibrary, string preloadLibraryName, string absolutePath)
+    {
+      SetSnapshot(new Snapshot(preloadLibrary, preloadLibraryName, absolutePath));
+    }
+
+    private static void SetSnapshot(Snapshot snapshot)
+    {
+      Volatile.Write(ref settings, snapshot);
     }
   }
 
@@ -442,6 +482,38 @@ namespace ROS2
     private static extern IntPtr dlerror ();
 
     const int RTLD_NOW = 2;
+    private static string preloadedLibraryKey = "";
+    private static NativeLibraryHandle preloadedLibraryHandle = null;
+    private static readonly object preloadMutex = new object();
+
+    private void CheckPreloadLibraries(GlobalVariables.Snapshot settings)
+    {
+      string preloadKey = settings.AbsolutePath + "|" + settings.PreloadLibraryName;
+      if (settings.PreloadLibraryName == "")
+      {
+        return;
+      }
+
+      lock (preloadMutex)
+      {
+        if (preloadedLibraryKey == preloadKey)
+        {
+          return;
+        }
+
+        Ros2csLogger.GetInstance().LogDebug("Preloading " + settings.PreloadLibraryName);
+        IntPtr libPtr = Load(settings.PreloadLibraryName, settings.AbsolutePath);
+        if (preloadedLibraryHandle != null)
+        {
+          preloadedLibraryHandle.Dispose();
+        }
+        preloadedLibraryHandle = NativeLibraryHandle.FromHandle(this, libPtr);
+
+        Ros2csLogger.GetInstance().LogDebug("Preloading " + settings.PreloadLibraryName + " successful.");
+
+        preloadedLibraryKey = preloadKey;
+      }
+    }
 
     public void FreeLibrary (IntPtr handle) {
       if (handle != IntPtr.Zero) {
@@ -460,22 +532,46 @@ namespace ROS2
       return res;
     }
 
+    private IntPtr Load(string libraryFileName, string absolutePath) {
+      string libraryPath = absolutePath + libraryFileName;
+      string dlopenSearchString = libraryPath;
+      Ros2csLogger.GetInstance().LogDebug("Loading lib: " + dlopenSearchString);
+      IntPtr ptr = dlopen(dlopenSearchString, RTLD_NOW);
+      if (ptr == IntPtr.Zero) {
+        if (!String.IsNullOrEmpty(absolutePath)) {
+          var errPtr = dlerror ();
+          Ros2csLogger.GetInstance().LogDebug("Could not find " + dlopenSearchString + ": " + Marshal.PtrToStringAnsi (errPtr) + ". Fallback to " + libraryFileName);
+          dlopenSearchString = libraryFileName;
+          ptr = dlopen(dlopenSearchString, RTLD_NOW);
+        }
+      }
+      if (ptr == IntPtr.Zero) {
+        var errPtr = dlerror ();
+        string detail = Marshal.PtrToStringAnsi (errPtr);
+        if (!String.IsNullOrEmpty(detail)) {
+          throw new UnsatisfiedLinkError(dlopenSearchString + ": " + detail);
+        }
+        throw new UnsatisfiedLinkError(dlopenSearchString);
+      }
+      Ros2csLogger.GetInstance().LogDebug("Loaded library: " + dlopenSearchString);
+      return ptr;
+    }
+
+    private IntPtr LoadLibraryByName(string libraryFileName) {
+      GlobalVariables.Snapshot settings = GlobalVariables.GetSnapshot();
+      if (settings.PreloadLibrary)
+        CheckPreloadLibraries(settings);
+      return Load(libraryFileName, settings.AbsolutePath);
+    }
+
     public IntPtr LoadLibrary (string fileName) {
       string libraryName = "lib" + fileName + "_native.dylib";
-      IntPtr ptr = dlopen (libraryName, RTLD_NOW);
-      if (ptr == IntPtr.Zero) {
-        throw new UnsatisfiedLinkError (libraryName);
-      }
-      return ptr;
+      return LoadLibraryByName(libraryName);
     }
 
     public IntPtr LoadLibraryNoSuffix (string fileName) {
       string libraryName = "lib" + fileName + ".dylib";
-      IntPtr ptr = dlopen (libraryName, RTLD_NOW);
-      if (ptr == IntPtr.Zero) {
-        throw new UnsatisfiedLinkError (libraryName);
-      }
-      return ptr;
+      return LoadLibraryByName(libraryName);
     }
   }
 }

--- a/src/ros2cs/ros2cs_common/Exceptions.cs
+++ b/src/ros2cs/ros2cs_common/Exceptions.cs
@@ -14,51 +14,94 @@
 // limitations under the License.
 
 using System;
+using System.Runtime.Serialization;
 
 namespace ROS2
 {
-    public class UnsatisfiedLinkError :Exception {
+    [Serializable]
+    public class UnsatisfiedLinkException : Exception {
+      public UnsatisfiedLinkException () : base() { }
+      public UnsatisfiedLinkException (string message) : base (message) { }
+      public UnsatisfiedLinkException (string message, System.Exception inner) : base (message, inner) { }
+      protected UnsatisfiedLinkException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+    }
+
+    [Serializable]
+    public class UnknownPlatformException : Exception {
+      public UnknownPlatformException () : base() { }
+      public UnknownPlatformException (string message) : base (message) { }
+      public UnknownPlatformException (string message, System.Exception inner) : base (message, inner) { }
+      protected UnknownPlatformException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+    }
+
+    [Serializable]
+    public class UnsatisfiedLinkError : UnsatisfiedLinkException {
       public UnsatisfiedLinkError () : base() { }
       public UnsatisfiedLinkError (string message) : base (message) { }
       public UnsatisfiedLinkError (string message, System.Exception inner) : base (message, inner) { }
+      protected UnsatisfiedLinkError(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 
-    public class UnknownPlatformError : Exception {
+    [Serializable]
+    public class UnknownPlatformError : UnknownPlatformException {
       public UnknownPlatformError () : base() { }
       public UnknownPlatformError (string message) : base (message) { }
       public UnknownPlatformError (string message, System.Exception inner) : base (message, inner) { }
+      protected UnknownPlatformError(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 
+    [Serializable]
     public class RuntimeError : Exception
     {
+      public int? ReturnCode { get; private set; }
+
       public RuntimeError() : base() {}
       public RuntimeError(string message) : base(message) {}
       public RuntimeError(string message, Exception inner) : base(message, inner) {}
+      public RuntimeError(string message, int returnCode) : base(message) { ReturnCode = returnCode; }
+      public RuntimeError(string message, int returnCode, Exception inner) : base(message, inner) { ReturnCode = returnCode; }
+      protected RuntimeError(SerializationInfo info, StreamingContext context) : base(info, context)
+      {
+        ReturnCode = (int?)info.GetValue(nameof(ReturnCode), typeof(int?));
+      }
+
+      public override void GetObjectData(SerializationInfo info, StreamingContext context)
+      {
+        base.GetObjectData(info, context);
+        info.AddValue(nameof(ReturnCode), ReturnCode, typeof(int?));
+      }
     }
 
-    public class NotInitializedException : Exception
+    [Serializable]
+    public class NotInitializedException : InvalidOperationException
     {
       public NotInitializedException() : base() {}
       public NotInitializedException(string message) : base(message) {}
       public NotInitializedException(string message, Exception inner) : base(message, inner) {}
+      protected NotInitializedException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 
-    public class InvalidNodeNameException : Exception
+    [Serializable]
+    public class InvalidNodeNameException : ArgumentException
     {
       public InvalidNodeNameException() : base() {}
       public InvalidNodeNameException(string message) : base(message) {}
       public InvalidNodeNameException(string message, Exception inner) : base(message, inner) {}
+      protected InvalidNodeNameException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 
-    public class InvalidNamespaceException : Exception
+    [Serializable]
+    public class InvalidNamespaceException : ArgumentException
     {
       public InvalidNamespaceException() : base() {}
       public InvalidNamespaceException(string message) : base(message) {}
       public InvalidNamespaceException(string message, Exception inner) : base(message, inner) {}
+      protected InvalidNamespaceException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
     /// <summary>
     /// Exception thrown when trying to wait on an empty wait set.
     /// </summary>
+    [Serializable]
     public class WaitSetEmptyException : InvalidOperationException
     {
       public WaitSetEmptyException() : base()
@@ -70,6 +113,9 @@ namespace ROS2
 
       /// <inheritdoc />
       public WaitSetEmptyException(string message, Exception innerException) : base(message, innerException)
+      { }
+
+      protected WaitSetEmptyException(SerializationInfo info, StreamingContext context) : base(info, context)
       { }
     }
 }

--- a/src/ros2cs/ros2cs_common/Exceptions.cs
+++ b/src/ros2cs/ros2cs_common/Exceptions.cs
@@ -22,6 +22,7 @@ using System.Runtime.Serialization;
 
 namespace ROS2
 {
+    /// <summary>Base exception for native library load failures. Prefer catching this type.</summary>
     [Serializable]
     public class UnsatisfiedLinkException : Exception {
       public UnsatisfiedLinkException () : base() { }
@@ -38,6 +39,10 @@ namespace ROS2
       protected UnknownPlatformException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 
+    /// <summary>
+    /// Concrete native library load failure thrown by current loader implementations.
+    /// Catch <see cref="UnsatisfiedLinkException"/> to handle all native link failures.
+    /// </summary>
     [Serializable]
     public class UnsatisfiedLinkError : UnsatisfiedLinkException {
       public UnsatisfiedLinkError () : base() { }

--- a/src/ros2cs/ros2cs_common/Exceptions.cs
+++ b/src/ros2cs/ros2cs_common/Exceptions.cs
@@ -1,5 +1,9 @@
 // Copyright 2019-2021 Robotec.ai
 // Copyright 2019 Dyno Robotics (by Samuel Lindgren samuel@dynorobotics.se)
+// Modifications Copyright (c) 2026 Jianbin Liu.
+//
+// Modifications by Jianbin Liu:
+// - Audited exception definitions for Jazzy lifecycle/error-path hardening.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/ros2cs/ros2cs_common/Message.cs
+++ b/src/ros2cs/ros2cs_common/Message.cs
@@ -16,12 +16,17 @@ using System;
 
 namespace ROS2
 {
-  /// <summary> Basic Message interface, only exposing Dispose method <summary>
+  /// <summary>Basic message interface, exposing disposal for native-backed generated messages.</summary>
+  /// <remarks>
+  /// The caller that creates a message owns disposal. Generated messages must be explicitly disposed
+  /// and must not declare finalizers that call native message destroy functions during process or
+  /// Unity domain teardown.
+  /// </remarks>
   public interface Message : IExtendedDisposable
   {
   }
 
-  /// <summary> Convenience interface to manipulate headers <summary>
+  /// <summary> Convenience interface to manipulate headers </summary>
   public interface MessageWithHeader : Message
   {
     void SetHeaderFrame(string frameID);

--- a/src/ros2cs/ros2cs_common/MessageInternals.cs
+++ b/src/ros2cs/ros2cs_common/MessageInternals.cs
@@ -66,26 +66,36 @@ namespace ROS2
       internal static IntPtr GetTypeSupportHandle<T>() where T : Message, new()
       {
         Type messageType = typeof(T);
+        IntPtr typeSupportHandle;
         lock (TypeSupportHandlesMutex)
         {
-          IntPtr typeSupportHandle;
           if (TypeSupportHandles.TryGetValue(messageType, out typeSupportHandle))
           {
             return typeSupportHandle;
           }
+        }
 
-          T msg = new T();
-          try
+        T msg = new T();
+        try
+        {
+          // Create one temporary generated message only when the type support handle is not cached yet.
+          typeSupportHandle = AsMessageInternals(msg, nameof(msg)).TypeSupportHandle;
+        }
+        finally
+        {
+          msg.Dispose();
+        }
+
+        lock (TypeSupportHandlesMutex)
+        {
+          IntPtr cachedTypeSupportHandle;
+          if (TypeSupportHandles.TryGetValue(messageType, out cachedTypeSupportHandle))
           {
-            // Create one temporary generated message only when the type support handle is not cached yet.
-            typeSupportHandle = AsMessageInternals(msg, nameof(msg)).TypeSupportHandle;
-            TypeSupportHandles[messageType] = typeSupportHandle;
-            return typeSupportHandle;
+            return cachedTypeSupportHandle;
           }
-          finally
-          {
-            msg.Dispose();
-          }
+
+          TypeSupportHandles[messageType] = typeSupportHandle;
+          return typeSupportHandle;
         }
       }
     }

--- a/src/ros2cs/ros2cs_common/MessageInternals.cs
+++ b/src/ros2cs/ros2cs_common/MessageInternals.cs
@@ -1,4 +1,5 @@
 // Copyright 2021 Robotec.ai
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Modifications by Jianbin Liu:
+// - Added safe MessageInternals validation helper.
+// - Cached message type support handles.
+
 using System;
+using System.Collections.Generic;
 
 namespace ROS2
 {
@@ -35,12 +41,52 @@ namespace ROS2
     /// <summary> An utility class to acquire type support for a given message type </summary>
     internal static class MessageTypeSupportHelper
     {
+      // Type support handles are process-stable, so cache them to avoid repeated temporary messages.
+      private static readonly object TypeSupportHandlesMutex = new object();
+      private static readonly Dictionary<Type, IntPtr> TypeSupportHandles = new Dictionary<Type, IntPtr>();
+
+      /// <summary>Validate that a generated message exposes the internal native-message contract.</summary>
+      internal static MessageInternals AsMessageInternals(Message message, string argumentName)
+      {
+        if (message == null)
+        {
+          throw new ArgumentNullException(argumentName);
+        }
+
+        MessageInternals messageInternals = message as MessageInternals;
+        if (messageInternals == null)
+        {
+          throw new InvalidOperationException(
+            message.GetType().FullName + " must implement ROS2.Internal.MessageInternals");
+        }
+
+        return messageInternals;
+      }
+
       internal static IntPtr GetTypeSupportHandle<T>() where T : Message, new()
       {
-        T msg = new T();
-        IntPtr typeSupportHandle = (msg as MessageInternals).TypeSupportHandle;
-        msg.Dispose();
-        return typeSupportHandle;
+        Type messageType = typeof(T);
+        lock (TypeSupportHandlesMutex)
+        {
+          IntPtr typeSupportHandle;
+          if (TypeSupportHandles.TryGetValue(messageType, out typeSupportHandle))
+          {
+            return typeSupportHandle;
+          }
+
+          T msg = new T();
+          try
+          {
+            // Create one temporary generated message only when the type support handle is not cached yet.
+            typeSupportHandle = AsMessageInternals(msg, nameof(msg)).TypeSupportHandle;
+            TypeSupportHandles[messageType] = typeSupportHandle;
+            return typeSupportHandle;
+          }
+          finally
+          {
+            msg.Dispose();
+          }
+        }
       }
     }
   } // namespace Internal

--- a/src/ros2cs/ros2cs_common/MessageInternals.cs
+++ b/src/ros2cs/ros2cs_common/MessageInternals.cs
@@ -25,11 +25,13 @@ namespace ROS2
   namespace Internal
   { // TODO (adamdbrw) a namespace to warn where design did not deliver.
 
-    /// <summary> Message interface that is meant to be internal </summary>
-    /// <remarks> Not sure if it is possible to make this internal
-    /// Note that this has to be visible between message assemblies (e.g. calling for nested messages)
-    /// as well as for all messages (custom, generated, in principle unknown to ros2cs_core).
-    /// It also needs to be visible to ros2cs_core classes. </remarks>
+    /// <summary>Native message contract exposed by generated message assemblies.</summary>
+    /// <remarks>
+    /// This interface is public only because generated message assemblies, custom message assemblies,
+    /// nested message implementations, and ros2cs_core must share one native-message contract. It is
+    /// not an application-level API; external callers should use the public message, publisher,
+    /// subscription, service, and client APIs instead of calling these members directly.
+    /// </remarks>
     public interface MessageInternals
     {
       IntPtr Handle { get; }

--- a/src/ros2cs/ros2cs_common/Ros2csLogger.cs
+++ b/src/ros2cs/ros2cs_common/Ros2csLogger.cs
@@ -17,6 +17,7 @@
 // - Made singleton initialization and logger callbacks thread-safe.
 // - Serialized console formatting to reduce interleaved log noise.
 // - Added PascalCase callback registration while retaining the legacy method.
+// - Isolated application logger callback exceptions from ros2cs callers.
 
 using System;
 using System.Collections.Generic;
@@ -127,7 +128,14 @@ namespace ROS2
 
       // Threshold and callback are a snapshot: later LogLevel changes do not cancel a message already accepted.
       // Invoke application callbacks outside the console lock so custom loggers cannot block formatting.
-      callback?.Invoke("[ROS2CS] " + message);
+      try
+      {
+        callback?.Invoke("[ROS2CS] " + message);
+      }
+      catch (Exception e)
+      {
+        Console.Error.WriteLine("[ROS2CS] Logger callback failed: " + e);
+      }
 
       lock (LoggerMutex)
       {

--- a/src/ros2cs/ros2cs_common/Ros2csLogger.cs
+++ b/src/ros2cs/ros2cs_common/Ros2csLogger.cs
@@ -1,4 +1,5 @@
 // Copyright 2021 Robotec.ai
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// Modifications by Jianbin Liu:
+// - Made singleton initialization and logger callbacks thread-safe.
+// - Serialized console formatting to reduce interleaved log noise.
 
 using System;
 using System.Collections.Generic;
@@ -29,7 +34,11 @@ namespace ROS2
   public class Ros2csLogger
   {
     private Ros2csLogger() { }
-    private static Ros2csLogger _instance;
+    // Lazy<T> gives thread-safe singleton creation without a manual double-check lock.
+    private static readonly Lazy<Ros2csLogger> Instance = new Lazy<Ros2csLogger>(() => new Ros2csLogger());
+    // Protects mutable log level, callbacks, and console color writes.
+    private static readonly object LoggerMutex = new object();
+    private static LogLevel logLevel;
 
     public delegate void Callback(object message);
 
@@ -41,7 +50,24 @@ namespace ROS2
       {LogLevel.ERROR, "ERROR"},
     };
 
-    public static LogLevel LogLevel { get; set; }
+    /// <summary>Minimum level that will be emitted by the logger.</summary>
+    public static LogLevel LogLevel
+    {
+      get
+      {
+        lock (LoggerMutex)
+        {
+          return logLevel;
+        }
+      }
+      set
+      {
+        lock (LoggerMutex)
+        {
+          logLevel = value;
+        }
+      }
+    }
 
     private static Dictionary<LogLevel, Callback> LevelCallbacks = new Dictionary<LogLevel, Callback>()
     {
@@ -66,18 +92,17 @@ namespace ROS2
     /// <param name="cb"> Callback (logging mechanism) to execute when logging </param>
     public static void setCallback(LogLevel level, Callback cb)
     {
-      LevelCallbacks[level] = cb;
+      lock (LoggerMutex)
+      {
+        LevelCallbacks[level] = cb;
+      }
     }
 
     /// <summary> Acquire the singleton </summary>
     /// <description> Implements lazy construction </description>
     public static Ros2csLogger GetInstance()
     {
-      if (_instance == null)
-      {
-        _instance = new Ros2csLogger();
-      }
-      return _instance;
+      return Instance.Value;
     }
 
     /// <summary> Log a given message with a set level </summary>
@@ -85,22 +110,35 @@ namespace ROS2
     /// <param name="message"> Message to log </param>
     public void Log(LogLevel level, String message)
     {
-      if (Ros2csLogger.LogLevel > level) return;
-
-      ConsoleColor prevForeground = Console.ForegroundColor;
-      Console.ForegroundColor = Ros2csLogger.LevelColors[level];
-      if(Ros2csLogger.LevelCallbacks[level] != null)
+      Callback callback;
+      lock (LoggerMutex)
       {
-        Ros2csLogger.LevelCallbacks[level]("[ROS2CS] " + message);
+        if (logLevel > level) return;
+        callback = Ros2csLogger.LevelCallbacks[level];
       }
-      Console.WriteLine(
-          "[" +
-          DateTime.Now.ToString("HH:mm:ss.ffffff") +
-          "][" +
-          Ros2csLogger.LevelNames[level] +
-          "] " +
-          message);
-      Console.ForegroundColor = prevForeground;
+
+      // Invoke application callbacks outside the console lock so custom loggers cannot block formatting.
+      callback?.Invoke("[ROS2CS] " + message);
+
+      lock (LoggerMutex)
+      {
+        ConsoleColor prevForeground = Console.ForegroundColor;
+        try
+        {
+          Console.ForegroundColor = Ros2csLogger.LevelColors[level];
+          Console.WriteLine(
+            "[" +
+            DateTime.Now.ToString("HH:mm:ss.ffffff") +
+            "][" +
+            Ros2csLogger.LevelNames[level] +
+            "] " +
+            message);
+        }
+        finally
+        {
+          Console.ForegroundColor = prevForeground;
+        }
+      }
     }
 
     public void LogInfo(String message)

--- a/src/ros2cs/ros2cs_common/Ros2csLogger.cs
+++ b/src/ros2cs/ros2cs_common/Ros2csLogger.cs
@@ -16,6 +16,7 @@
 // Modifications by Jianbin Liu:
 // - Made singleton initialization and logger callbacks thread-safe.
 // - Serialized console formatting to reduce interleaved log noise.
+// - Added PascalCase callback registration while retaining the legacy method.
 
 using System;
 using System.Collections.Generic;
@@ -38,7 +39,7 @@ namespace ROS2
     private static readonly Lazy<Ros2csLogger> Instance = new Lazy<Ros2csLogger>(() => new Ros2csLogger());
     // Protects mutable log level, callbacks, and console color writes.
     private static readonly object LoggerMutex = new object();
-    private static LogLevel logLevel;
+    private static LogLevel _logLevel;
 
     public delegate void Callback(object message);
 
@@ -57,14 +58,14 @@ namespace ROS2
       {
         lock (LoggerMutex)
         {
-          return logLevel;
+          return _logLevel;
         }
       }
       set
       {
         lock (LoggerMutex)
         {
-          logLevel = value;
+          _logLevel = value;
         }
       }
     }
@@ -90,12 +91,19 @@ namespace ROS2
     /// an application (e. g. in Unity3D) which is using it </description>
     /// <param name="level"> Log level as in LogLevel enum </param>
     /// <param name="cb"> Callback (logging mechanism) to execute when logging </param>
-    public static void setCallback(LogLevel level, Callback cb)
+    public static void SetCallback(LogLevel level, Callback cb)
     {
       lock (LoggerMutex)
       {
         LevelCallbacks[level] = cb;
       }
+    }
+
+    /// <summary>Legacy callback registration name retained for compatibility.</summary>
+    [Obsolete("Use SetCallback.")]
+    public static void setCallback(LogLevel level, Callback cb)
+    {
+      SetCallback(level, cb);
     }
 
     /// <summary> Acquire the singleton </summary>
@@ -113,10 +121,11 @@ namespace ROS2
       Callback callback;
       lock (LoggerMutex)
       {
-        if (logLevel > level) return;
+        if (_logLevel > level) return;
         callback = Ros2csLogger.LevelCallbacks[level];
       }
 
+      // Threshold and callback are a snapshot: later LogLevel changes do not cancel a message already accepted.
       // Invoke application callbacks outside the console lock so custom loggers cannot block formatting.
       callback?.Invoke("[ROS2CS] " + message);
 

--- a/src/ros2cs/ros2cs_common/interfaces/IExtendedDisposable.cs
+++ b/src/ros2cs/ros2cs_common/interfaces/IExtendedDisposable.cs
@@ -16,10 +16,15 @@ using System;
 
 namespace ROS2
 {
-  /// <summary> Extended Disposable interface to enable dispose check </summary>
-  /// <description> Use instead of IDisposable </description>
+  /// <summary>Extended disposable interface to expose object disposal state.</summary>
+  /// <remarks>
+  /// Implementations should document any thread-safety guarantees for <see cref="IsDisposed"/>.
+  /// Callers must not assume that checking <see cref="IsDisposed"/> makes a later operation safe
+  /// from races with another thread disposing the object.
+  /// </remarks>
   public interface IExtendedDisposable : IDisposable
   {
+    /// <summary>Whether this instance has been disposed.</summary>
     bool IsDisposed { get; }
   }
 

--- a/src/ros2cs/ros2cs_core/CMakeLists.txt
+++ b/src/ros2cs/ros2cs_core/CMakeLists.txt
@@ -377,7 +377,7 @@ if(STANDALONE_BUILD)
     rosidl_typesupport_introspection_cpp
     spdlog
     tracetools
-    yaml
+    yaml-cpp
     tinyxml2
   )
   

--- a/src/ros2cs/ros2cs_core/CMakeLists.txt
+++ b/src/ros2cs/ros2cs_core/CMakeLists.txt
@@ -238,7 +238,7 @@ if(STANDALONE_BUILD)
       endif()
 
       # Get rmw_cyclonedds_cpp for humble
-      if("${_library_name}" STREQUAL "rmw_cyclonedds_cpp" AND (ros2_distro STREQUAL "humble" OR ros2_distro STREQUAL "rolling"))
+      if("${_library_name}" STREQUAL "rmw_cyclonedds_cpp" AND (ros2_distro STREQUAL "humble" OR ros2_distro STREQUAL "jazzy" OR ros2_distro STREQUAL "rolling"))
         fetch_target_lib(rmw_cyclonedds_cpp::rmw_cyclonedds_cpp)
         list(APPEND REQ_STANDALONE_LIBS ${rmw_cyclonedds_cpp_rmw_cyclonedds_cpp_LIB_PATH})
       endif()

--- a/src/ros2cs/ros2cs_core/CMakeLists.txt
+++ b/src/ros2cs/ros2cs_core/CMakeLists.txt
@@ -1,4 +1,8 @@
 # Copyright 2019-2021 Robotec.ai
+# Modifications Copyright (c) 2026 Jianbin Liu.
+#
+# Modifications by Jianbin Liu:
+# - Updated standalone dependency closure and Jazzy runtime build metadata.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/ros2cs/ros2cs_core/CMakeLists.txt
+++ b/src/ros2cs/ros2cs_core/CMakeLists.txt
@@ -359,8 +359,12 @@ if(STANDALONE_BUILD)
 
   set(ros2_standalone_libs
     rcl
+    class_loader
+    libstatistics_collector
     rcl_logging_spdlog
     rcl_yaml_param_parser
+    rclcpp
+    rclcpp_action
     rcpputils
     rcutils
     rmw

--- a/src/ros2cs/ros2cs_core/CMakeLists.txt
+++ b/src/ros2cs/ros2cs_core/CMakeLists.txt
@@ -343,7 +343,7 @@ if(STANDALONE_BUILD)
 
       # Fix soversion files
       foreach(_resolvedFile ${_resolvedFiles})
-        if("${_resolvedFile}" MATCHES "so(\.[0-9]*)+$")
+        if("${_resolvedFile}" MATCHES "\\.so(\\.[0-9]+)+$")
           # message("Soversion file detected ${_resolvedFile}")
 
           # Get file path without so
@@ -351,7 +351,7 @@ if(STANDALONE_BUILD)
           string(SUBSTRING "${_resolvedFile}" 0 ${_findPos} _cutted)
 
           set(_remainingPath "${_resolvedFile}")
-          while("${_remainingPath}" MATCHES "so(\.[0-9]*)+$")
+          while("${_remainingPath}" MATCHES "\\.so(\\.[0-9]+)+$")
             string(FIND "${_remainingPath}" "." _lastDotPos REVERSE)
             string(SUBSTRING "${_remainingPath}" 0 ${_lastDotPos} _tempPos)
             get_filename_component(_libPathFilename "${_tempPos}" NAME)

--- a/src/ros2cs/ros2cs_core/CMakeLists.txt
+++ b/src/ros2cs/ros2cs_core/CMakeLists.txt
@@ -226,6 +226,27 @@ if(STANDALONE_BUILD)
         endif()
       endif()
 
+      # Get C++ runtime support libraries used by tf2/rclcpp based packages.
+      if(UNIX AND "${_library_name}" STREQUAL "class_loader")
+        fetch_target_lib(class_loader::class_loader)
+        list(APPEND REQ_STANDALONE_LIBS ${class_loader_class_loader_LIB_PATH})
+      endif()
+
+      if(UNIX AND "${_library_name}" STREQUAL "libstatistics_collector")
+        fetch_target_lib(libstatistics_collector::libstatistics_collector)
+        list(APPEND REQ_STANDALONE_LIBS ${libstatistics_collector_libstatistics_collector_LIB_PATH})
+      endif()
+
+      if(UNIX AND "${_library_name}" STREQUAL "rclcpp")
+        fetch_target_lib(rclcpp::rclcpp)
+        list(APPEND REQ_STANDALONE_LIBS ${rclcpp_rclcpp_LIB_PATH})
+      endif()
+
+      if(UNIX AND "${_library_name}" STREQUAL "rclcpp_action")
+        fetch_target_lib(rclcpp_action::rclcpp_action)
+        list(APPEND REQ_STANDALONE_LIBS ${rclcpp_action_rclcpp_action_LIB_PATH})
+      endif()
+
       # Get spdlog and dependency
       if(UNIX AND "${_library_name}" STREQUAL "spdlog")
         include(${${_library_name}_CONFIG})

--- a/src/ros2cs/ros2cs_core/CMakeLists.txt
+++ b/src/ros2cs/ros2cs_core/CMakeLists.txt
@@ -71,7 +71,9 @@ ament_export_libraries(ros2cs_native)
 ament_export_targets(ros2cs_native)
 configure_csharp_c_extension_library(ros2cs_native)
 
-set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")
+if(UNIX AND NOT APPLE)
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")
+endif()
 
 set(CS_INTERFACES
   interfaces/INode.cs

--- a/src/ros2cs/ros2cs_core/CMakeLists.txt
+++ b/src/ros2cs/ros2cs_core/CMakeLists.txt
@@ -161,7 +161,7 @@ if(STANDALONE_BUILD)
   set(REQ_STANDALONE_DLLS "")
 
   macro(get_standalone_third_party_dependencies _library_name)
-    find_file(${_library_name}_PATH "${_library_name}")
+    find_file(${_library_name}_PATH NAMES ${ARGN} "${_library_name}")
     if("${${_library_name}_PATH}" STREQUAL "${_library_name}_PATH-NOTFOUND")
       message( FATAL_ERROR "Can't find third party dependency: ${_library_name}" )
     endif()
@@ -395,12 +395,17 @@ if(STANDALONE_BUILD)
   install_standalone_dependencies()
 
   if(WIN32)
+    get_standalone_third_party_dependencies(openssl_ssl libssl-3-x64.dll libssl-1_1-x64.dll)
+    get_standalone_third_party_dependencies(openssl_crypto libcrypto-3-x64.dll libcrypto-1_1-x64.dll)
+
     set(third_party_standalone_libs
-      libssl-1_1-x64.dll
-      libcrypto-1_1-x64.dll
       msvcp140.dll
       vcruntime140.dll
       vcruntime140_1.dll
+      yaml.dll
+      yaml-cpp.dll
+      spdlog.dll
+      fmt.dll
       tinyxml2.dll
     )
     foreach(third_party_lib ${third_party_standalone_libs})

--- a/src/ros2cs/ros2cs_core/Client.cs
+++ b/src/ros2cs/ros2cs_core/Client.cs
@@ -18,6 +18,7 @@
 // - Reworked client handle and options ownership.
 // - Added response cleanup and spin callback reentry guard.
 // - Added timeout-capable synchronous calls and removed exception-driven cancellation lookup.
+// - Made disposal state volatile for node/entity visibility.
 
 using System;
 using System.Collections;
@@ -77,7 +78,7 @@ namespace ROS2
 
     /// <inheritdoc/>
     public bool IsDisposed { get { return disposed; } }
-    private bool disposed = false;
+    private volatile bool disposed = false;
 
     /// <summary>
     /// Internal constructor for Client

--- a/src/ros2cs/ros2cs_core/Client.cs
+++ b/src/ros2cs/ros2cs_core/Client.cs
@@ -232,13 +232,21 @@ namespace ROS2
     /// <inheritdoc/>
     public bool IsServiceAvailable()
     {
-      bool available = false;
-      Utils.CheckReturnEnum(NativeRcl.rcl_service_server_is_available(
-        ref node.nodeHandle,
-        ref clientHandle,
-        ref available
-      ));
-      return available;
+      lock (mutex)
+      {
+        if (disposed || node.IsDisposed || !Ros2cs.Ok())
+        {
+          return false;
+        }
+
+        bool available = false;
+        Utils.CheckReturnEnum(NativeRcl.rcl_service_server_is_available(
+          ref node.nodeHandle,
+          ref clientHandle,
+          ref available
+        ));
+        return available;
+      }
     }
 
     /// <inheritdoc/>

--- a/src/ros2cs/ros2cs_core/Client.cs
+++ b/src/ros2cs/ros2cs_core/Client.cs
@@ -160,7 +160,7 @@ namespace ROS2
     /// <summary>Shared client disposal path used by explicit disposal, node disposal, and finalization.</summary>
     private void Dispose(bool disposing)
     {
-      Exception disposeException = null;
+      List<Exception> disposeExceptions = null;
       lock (mutex)
       {
         if (disposed)
@@ -193,7 +193,7 @@ namespace ROS2
         {
           if (disposing)
           {
-            disposeException = e;
+            Utils.AddException(ref disposeExceptions, e);
           }
         }
         finally
@@ -207,9 +207,9 @@ namespace ROS2
           }
           catch (Exception e)
           {
-            if (disposing && disposeException == null)
+            if (disposing)
             {
-              disposeException = e;
+              Utils.AddException(ref disposeExceptions, e);
             }
           }
           finally
@@ -223,10 +223,7 @@ namespace ROS2
       if (disposing)
       {
         logger.LogInfo("Client destroyed");
-        if (disposeException != null)
-        {
-          throw disposeException;
-        }
+        Utils.ThrowCollectedExceptions(disposeExceptions);
       }
     }
 
@@ -383,8 +380,7 @@ namespace ROS2
       }
 
       var task = CallAsync(msg);
-      task.Wait();
-      return task.Result;
+      return task.GetAwaiter().GetResult();
     }
 
     /// <inheritdoc/>
@@ -397,12 +393,13 @@ namespace ROS2
       }
 
       var task = CallAsync(msg);
-      if (!task.Wait(timeout))
+      var completedTask = Task.WhenAny(task, Task.Delay(timeout)).GetAwaiter().GetResult();
+      if (!ReferenceEquals(completedTask, task))
       {
         Cancel(task);
         throw new TimeoutException("Timed out waiting for service response on topic '" + topic + "'");
       }
-      return task.Result;
+      return task.GetAwaiter().GetResult();
     }
 
     /// <inheritdoc/>

--- a/src/ros2cs/ros2cs_core/Client.cs
+++ b/src/ros2cs/ros2cs_core/Client.cs
@@ -17,6 +17,7 @@
 // - Added node-owned disposal path and graceful request cancellation.
 // - Reworked client handle and options ownership.
 // - Added response cleanup and spin callback reentry guard.
+// - Added timeout-capable synchronous calls and removed exception-driven cancellation lookup.
 
 using System;
 using System.Collections;
@@ -82,7 +83,7 @@ namespace ROS2
     /// Internal constructor for Client
     /// </summary>
     /// <remarks>Use <see cref="INode.CreateClient"/> to construct new Instances</remarks>
-    public Client(string pubTopic, Node node, QualityOfServiceProfile qos = null)
+    internal Client(string pubTopic, Node node, QualityOfServiceProfile qos = null)
     {
       topic = pubTopic;
       this.node = node;
@@ -387,6 +388,24 @@ namespace ROS2
     }
 
     /// <inheritdoc/>
+    public O Call(I msg, TimeSpan timeout)
+    {
+      if (Ros2cs.IsInSpinCallback)
+      {
+        // A blocking call from a spin callback would wait for the same spin loop that is currently busy.
+        throw new InvalidOperationException("Synchronous Client.Call cannot be used from a spin callback; use CallAsync instead.");
+      }
+
+      var task = CallAsync(msg);
+      if (!task.Wait(timeout))
+      {
+        Cancel(task);
+        throw new TimeoutException("Timed out waiting for service response on topic '" + topic + "'");
+      }
+      return task.Result;
+    }
+
+    /// <inheritdoc/>
     public Task<O> CallAsync(I msg)
     {
       return CallAsync(msg, TaskCreationOptions.None);
@@ -415,20 +434,34 @@ namespace ROS2
     /// <inheritdoc/>
     public bool Cancel(Task task)
     {
-      var pair = default(KeyValuePair<long, (TaskCompletionSource<O>, Task<O>)>);
-      try
+      (TaskCompletionSource<O>, Task<O>) source = default((TaskCompletionSource<O>, Task<O>));
+      bool found = false;
+      long sequenceNumber = default(long);
+
+      lock(this.Requests)
       {
-        lock(this.Requests)
+        foreach (var entry in this.Requests)
         {
-          pair = this.Requests.First(entry => entry.Value.Item2 == task);
-          this.Requests.Remove(pair.Key);
+          if (entry.Value.Item2 == task)
+          {
+            sequenceNumber = entry.Key;
+            source = entry.Value;
+            found = true;
+            break;
+          }
+        }
+
+        if (found)
+        {
+          this.Requests.Remove(sequenceNumber);
         }
       }
-      catch (InvalidOperationException)
+
+      if (!found)
       {
         return false;
       }
-      return pair.Value.Item1.TrySetCanceled();
+      return source.Item1.TrySetCanceled();
     }
 
     /// <summary>

--- a/src/ros2cs/ros2cs_core/Client.cs
+++ b/src/ros2cs/ros2cs_core/Client.cs
@@ -1,4 +1,5 @@
 // Copyright 2019-2021 Robotec.ai
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Modifications by Jianbin Liu:
+// - Added node-owned disposal path and graceful request cancellation.
+// - Reworked client handle and options ownership.
+// - Added response cleanup and spin callback reentry guard.
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -20,21 +26,21 @@ using System.Linq;
 using System.Threading.Tasks;
 using ROS2.Internal;
 
-
 namespace ROS2
 {
-  /// <summary>Client with a topic and Types for Messages</summary>
+  /// <summary>Client with a topic, message types, and node-owned native lifetime.</summary>
   /// <remarks>Instances are created by <see cref="INode.CreateClient"/></remarks>
   /// <typeparam name="I">Message Type to be send</typeparam>
   /// <typeparam name="O">Message Type to be received</typeparam>
-  public class Client<I, O>: IClient<I, O>
+  public class Client<I, O>: IClient<I, O>, INodeChildEntity
     where I : Message, new()
     where O : Message, new()
   {
     /// <inheritdoc/>
     public string Topic { get { return topic; } }
 
-    public rcl_client_t Handle { get { return serviceHandle; } }
+    /// <inheritdoc/>
+    public rcl_client_t Handle { get { return clientHandle; } }
 
     /// <inheritdoc/>
     public IReadOnlyDictionary<long, Task<O>> PendingRequests {get; private set;}
@@ -60,11 +66,13 @@ namespace ROS2
 
     private Ros2csLogger logger = Ros2csLogger.GetInstance();
 
-    rcl_client_t serviceHandle;
+    // Native client/options handles are finalized before the owning node is finalized.
+    private rcl_client_t clientHandle;
 
-    IntPtr serviceOptions = IntPtr.Zero;
+    private IntPtr clientOptions = IntPtr.Zero;
 
-    rcl_node_t nodeHandle;
+    // Keep the owning node reference so fini calls always use the current native node handle.
+    private readonly Node node;
 
     /// <inheritdoc/>
     public bool IsDisposed { get { return disposed; } }
@@ -77,58 +85,146 @@ namespace ROS2
     public Client(string pubTopic, Node node, QualityOfServiceProfile qos = null)
     {
       topic = pubTopic;
-      nodeHandle = node.nodeHandle;
+      this.node = node;
 
       QualityOfServiceProfile qualityOfServiceProfile = qos;
+      bool ownsQos = false;
       if (qualityOfServiceProfile == null)
+      {
         qualityOfServiceProfile = new QualityOfServiceProfile(QosPresetProfile.SERVICES_DEFAULT);
+        ownsQos = true;
+      }
 
       Requests = new Dictionary<long, (TaskCompletionSource<O>, Task<O>)>();
       PendingRequests = new PendingTasksView(Requests);
 
-      serviceOptions = NativeRclInterface.rclcs_client_create_options(qualityOfServiceProfile.handle);
+      try
+      {
+        clientOptions = NativeRclInterface.rclcs_client_create_options(qualityOfServiceProfile.Handle);
+        if (clientOptions == IntPtr.Zero)
+        {
+          throw new RuntimeError("Failed to create client options");
+        }
+      }
+      finally
+      {
+        if (ownsQos)
+        {
+          qualityOfServiceProfile.Dispose();
+        }
+      }
 
       IntPtr typeSupportHandle = MessageTypeSupportHelper.GetTypeSupportHandle<I>();
 
-      serviceHandle = NativeRcl.rcl_get_zero_initialized_client();
-      Utils.CheckReturnEnum(NativeRcl.rcl_client_init(
-                              ref serviceHandle,
-                              ref nodeHandle,
-                              typeSupportHandle,
-                              topic,
-                              serviceOptions));
+      clientHandle = NativeRcl.rcl_get_zero_initialized_client();
+      try
+      {
+        Utils.CheckReturnEnum(NativeRcl.rcl_client_init(
+                                ref clientHandle,
+                                ref node.nodeHandle,
+                                typeSupportHandle,
+                                topic,
+                                clientOptions));
+      }
+      catch
+      {
+        NativeRclInterface.rclcs_client_dispose_options(clientOptions);
+        clientOptions = IntPtr.Zero;
+        throw;
+      }
     }
 
     ~Client()
     {
-      Dispose();
+      Dispose(false);
     }
 
+    /// <summary>Release the client and fail any still-pending requests.</summary>
     public void Dispose()
     {
-      DestroyClient();
+      Dispose(true);
+      GC.SuppressFinalize(this);
     }
 
-    /// <summary> "Destructor" supporting disposable model </summary>
-    private void DestroyClient()
+    /// <summary>Release this client during node disposal without re-entering node removal.</summary>
+    void INodeChildEntity.DisposeFromNode(bool disposing)
     {
+      Dispose(disposing);
+      if (disposing)
+      {
+        GC.SuppressFinalize(this);
+      }
+    }
+
+    /// <summary>Shared client disposal path used by explicit disposal, node disposal, and finalization.</summary>
+    private void Dispose(bool disposing)
+    {
+      Exception disposeException = null;
       lock (mutex)
       {
-        if (!disposed)
+        if (disposed)
         {
-          lock (Requests)
+          return;
+        }
+
+        // Complete pending calls so callers do not wait forever after shutdown/reconnect.
+        lock (Requests)
+        {
+          foreach (var source in Requests.Values)
           {
-            foreach (var source in Requests.Values)
-            {
-              bool success = source.Item1.TrySetException(new ObjectDisposedException("client has been disposed"));
-              Debug.Assert(success);
-            }
-            Requests.Clear();
+            source.Item1.TrySetException(new ObjectDisposedException("client has been disposed"));
           }
-          Utils.CheckReturnEnum(NativeRcl.rcl_client_fini(ref serviceHandle, ref nodeHandle));
-          NativeRclInterface.rclcs_client_dispose_options(serviceOptions);
-          logger.LogInfo("Client destroyed");
-          disposed = true;
+          Requests.Clear();
+        }
+
+        try
+        {
+          if (!node.IsDisposed)
+          {
+            int ret = NativeRcl.rcl_client_fini(ref clientHandle, ref node.nodeHandle);
+            if (disposing)
+            {
+              Utils.CheckReturnEnum(ret);
+            }
+          }
+        }
+        catch (Exception e)
+        {
+          if (disposing)
+          {
+            disposeException = e;
+          }
+        }
+        finally
+        {
+          try
+          {
+            if (clientOptions != IntPtr.Zero)
+            {
+              NativeRclInterface.rclcs_client_dispose_options(clientOptions);
+            }
+          }
+          catch (Exception e)
+          {
+            if (disposing && disposeException == null)
+            {
+              disposeException = e;
+            }
+          }
+          finally
+          {
+            clientOptions = IntPtr.Zero;
+            disposed = true;
+          }
+        }
+      }
+
+      if (disposing)
+      {
+        logger.LogInfo("Client destroyed");
+        if (disposeException != null)
+        {
+          throw disposeException;
         }
       }
     }
@@ -138,8 +234,8 @@ namespace ROS2
     {
       bool available = false;
       Utils.CheckReturnEnum(NativeRcl.rcl_service_server_is_available(
-        ref nodeHandle,
-        ref serviceHandle,
+        ref node.nodeHandle,
+        ref clientHandle,
         ref available
       ));
       return available;
@@ -148,34 +244,66 @@ namespace ROS2
     /// <inheritdoc/>
     public void TakeMessage()
     {
-      MessageInternals msg = new O() as MessageInternals;
-      rcl_rmw_request_id_t request_header = default(rcl_rmw_request_id_t);
-      int ret;
+      MessageInternals msg = null;
+      rcl_rmw_request_id_t requestHeader = default(rcl_rmw_request_id_t);
+      RCLReturnEnum ret;
       lock (mutex)
       {
         if (disposed || !Ros2cs.Ok())
         {
           return;
         }
-        ret = NativeRcl.rcl_take_response(
-          ref serviceHandle,
-          ref request_header,
+
+        msg = CreateResponseMessage();
+        ret = (RCLReturnEnum)NativeRcl.rcl_take_response(
+          ref clientHandle,
+          ref requestHeader,
           msg.Handle
         );
       }
-      if ((RCLReturnEnum)ret != RCLReturnEnum.RCL_RET_CLIENT_TAKE_FAILED)
+
+      if (ret == RCLReturnEnum.RCL_RET_CLIENT_TAKE_FAILED)
       {
-        Utils.CheckReturnEnum(ret);
-        ProcessResponse(request_header.sequence_number, msg);
+        ((IDisposable)msg).Dispose();
+        return;
+      }
+
+      if (ret != RCLReturnEnum.RCL_RET_OK)
+      {
+        ((IDisposable)msg).Dispose();
+        Utils.CheckReturnEnum((int)ret);
+        return;
+      }
+
+      bool processed = ProcessResponse(requestHeader.sequence_number, msg);
+      if (!processed)
+      {
+        ((IDisposable)msg).Dispose();
+      }
+    }
+
+    /// <summary>Create a response message and validate its native-message interface.</summary>
+    private MessageInternals CreateResponseMessage()
+    {
+      O msg = new O();
+      try
+      {
+        return MessageTypeSupportHelper.AsMessageInternals(msg, nameof(msg));
+      }
+      catch
+      {
+        msg.Dispose();
+        throw;
       }
     }
 
     /// <summary>
-    /// Populates managed fields with native values and finishes the corresponding <see cref="Task"/> 
+    /// Populates managed fields with native values and finishes the corresponding <see cref="Task"/>
     /// </summary>
-    /// <param name="message">Message that will be populated and used as the task result</param>
-    /// <param name="header">sequence number received when sending the Request</param>
-    private void ProcessResponse(long sequence_number, MessageInternals msg)
+    /// <param name="msg">Message that will be populated and used as the task result</param>
+    /// <param name="sequence_number">sequence number received when sending the Request</param>
+    /// <returns>True when the response matched a pending request and now owns the message.</returns>
+    private bool ProcessResponse(long sequence_number, MessageInternals msg)
     {
       bool exists = false;
       (TaskCompletionSource<O>, Task<O>) source = default((TaskCompletionSource<O>, Task<O>));
@@ -191,10 +319,12 @@ namespace ROS2
       {
         msg.ReadNativeMessage();
         source.Item1.SetResult((O)msg);
+        return true;
       }
       else
       {
         Debug.Print("received unknown sequence number or got disposed");
+        return false;
       }
     }
 
@@ -206,11 +336,11 @@ namespace ROS2
     private long SendRequest(I msg)
     {
       long sequence_number = default(long);
-      MessageInternals msgInternals = msg as MessageInternals;
+      MessageInternals msgInternals = MessageTypeSupportHelper.AsMessageInternals(msg, nameof(msg));
       msgInternals.WriteNativeMessage();
       Utils.CheckReturnEnum(
         NativeRcl.rcl_send_request(
-          ref serviceHandle,
+          ref clientHandle,
           msgInternals.Handle,
           ref sequence_number
         )
@@ -237,6 +367,12 @@ namespace ROS2
     /// <inheritdoc/>
     public O Call(I msg)
     {
+      if (Ros2cs.IsInSpinCallback)
+      {
+        // A blocking call from a spin callback would wait for the same spin loop that is currently busy.
+        throw new InvalidOperationException("Synchronous Client.Call cannot be used from a spin callback; use CallAsync instead.");
+      }
+
       var task = CallAsync(msg);
       task.Wait();
       return task.Result;
@@ -256,9 +392,12 @@ namespace ROS2
       {
           if (!Ros2cs.Ok() || disposed)
           {
-            throw new InvalidOperationException("Cannot service as the class is already disposed or shutdown was called");
+            throw new InvalidOperationException("Cannot call as the class is already disposed or shutdown was called");
           }
-          // prevent TakeMessage from receiving Responses before we called RegisterSource
+          if (node.IsDisposed)
+          {
+            throw new InvalidOperationException("Cannot call as the owning node is already disposed");
+          }
           long sequence_number = SendRequest(msg);
           source = new TaskCompletionSource<O>(options);
           return RegisterSource(source, sequence_number);
@@ -274,7 +413,6 @@ namespace ROS2
         lock(this.Requests)
         {
           pair = this.Requests.First(entry => entry.Value.Item2 == task);
-          // has to be true
           this.Requests.Remove(pair.Key);
         }
       }
@@ -282,8 +420,7 @@ namespace ROS2
       {
         return false;
       }
-      pair.Value.Item1.SetCanceled();
-      return true;
+      return pair.Value.Item1.TrySetCanceled();
     }
 
     /// <summary>

--- a/src/ros2cs/ros2cs_core/Clock.cs
+++ b/src/ros2cs/ros2cs_core/Clock.cs
@@ -80,6 +80,11 @@ namespace ROS2
         nanoseconds += NanosecondsPerSecond;
       }
 
+      if (seconds < int.MinValue || seconds > int.MaxValue)
+      {
+        throw new OverflowException("ROS time seconds exceed the int32 range of builtin_interfaces/msg/Time");
+      }
+
       RosTime time = new RosTime();
       time.sec = (int)seconds;
       time.nanosec = (uint)nanoseconds;
@@ -111,6 +116,7 @@ namespace ROS2
     /// <summary>Shared clock disposal path used by explicit disposal and the finalizer.</summary>
     private void Dispose(bool disposing)
     {
+      Exception disposeException = null;
       lock (mutex)
       {
         if (disposed)
@@ -125,14 +131,23 @@ namespace ROS2
             NativeRclInterface.rclcs_ros_clock_dispose(handle);
           }
         }
-        catch
+        catch (Exception e)
         {
+          if (disposing)
+          {
+            disposeException = e;
+          }
         }
         finally
         {
           handle = IntPtr.Zero;
           disposed = true;
         }
+      }
+
+      if (disposeException != null)
+      {
+        throw disposeException;
       }
     }
   }

--- a/src/ros2cs/ros2cs_core/Clock.cs
+++ b/src/ros2cs/ros2cs_core/Clock.cs
@@ -1,5 +1,6 @@
 // Copyright 2019-2021 Robotec.ai
 // Copyright 2019 Dyno Robotics (by Samuel Lindgren samuel@dynorobotics.se)
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +13,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// Modifications by Jianbin Liu:
+// - Added nanosecond normalization helper for negative time values.
+// - Added safe clock creation validation and disposal handling.
 
 using System;
 using System.Collections.Generic;
@@ -35,6 +40,10 @@ namespace ROS2
   /// <summary> A clock class which queries an internal rcl clock and exposes RosTime </summary>
   public class Clock : IExtendedDisposable
   {
+    /// <summary>Number of nanoseconds in one second, used for lossless normalization.</summary>
+    private const long NanosecondsPerSecond = 1000000000L;
+    // Serializes native clock reads with disposal/finalizer cleanup.
+    private readonly object mutex = new object();
     internal IntPtr handle;
     private bool disposed;
 
@@ -46,32 +55,84 @@ namespace ROS2
     {
       get
       {
-        RosTime time = new RosTime();
-        long queryNowNanoseconds = 0;
-        NativeRcl.rcl_clock_get_now(handle, ref queryNowNanoseconds);
-        time.sec = (int)(queryNowNanoseconds / (long)1e9);
-        time.nanosec = (uint)(queryNowNanoseconds - time.sec*((long)1e9));
-        return time;
+        lock (mutex)
+        {
+          if (disposed)
+          {
+            throw new ObjectDisposedException(nameof(Clock));
+          }
+
+          long queryNowNanoseconds = 0;
+          Utils.CheckReturnEnum(NativeRcl.rcl_clock_get_now(handle, ref queryNowNanoseconds));
+          return FromNanoseconds(queryNowNanoseconds);
+        }
       }
+    }
+
+    /// <summary>Normalize signed nanoseconds into ROS seconds plus non-negative nanoseconds.</summary>
+    internal static RosTime FromNanoseconds(long nanosecondsSinceEpoch)
+    {
+      long seconds = nanosecondsSinceEpoch / NanosecondsPerSecond;
+      long nanoseconds = nanosecondsSinceEpoch % NanosecondsPerSecond;
+      if (nanoseconds < 0)
+      {
+        seconds--;
+        nanoseconds += NanosecondsPerSecond;
+      }
+
+      RosTime time = new RosTime();
+      time.sec = (int)seconds;
+      time.nanosec = (uint)nanoseconds;
+      return time;
     }
 
     public Clock()
     {
       rcl_allocator_t allocator = NativeRcl.rcutils_get_default_allocator();
       handle = NativeRclInterface.rclcs_ros_clock_create(ref allocator);
+      if (handle == IntPtr.Zero)
+      {
+        throw new RuntimeError("Failed to create ROS clock");
+      }
     }
 
     ~Clock()
     {
-      Dispose();
+      Dispose(false);
     }
 
+    /// <summary>Release the native ROS clock wrapper.</summary>
     public void Dispose()
     {
-      if (!disposed)
+      Dispose(true);
+      GC.SuppressFinalize(this);
+    }
+
+    /// <summary>Shared clock disposal path used by explicit disposal and the finalizer.</summary>
+    private void Dispose(bool disposing)
+    {
+      lock (mutex)
       {
-        NativeRclInterface.rclcs_ros_clock_dispose(handle);
-        disposed = true;
+        if (disposed)
+        {
+          return;
+        }
+
+        try
+        {
+          if (handle != IntPtr.Zero)
+          {
+            NativeRclInterface.rclcs_ros_clock_dispose(handle);
+          }
+        }
+        catch
+        {
+        }
+        finally
+        {
+          handle = IntPtr.Zero;
+          disposed = true;
+        }
       }
     }
   }

--- a/src/ros2cs/ros2cs_core/Clock.cs
+++ b/src/ros2cs/ros2cs_core/Clock.cs
@@ -17,6 +17,7 @@
 // Modifications by Jianbin Liu:
 // - Added nanosecond normalization helper for negative time values.
 // - Added safe clock creation validation and disposal handling.
+// - Documented context-independent ROS clock behavior.
 
 using System;
 using System.Collections.Generic;
@@ -38,6 +39,11 @@ namespace ROS2
   }
 
   /// <summary> A clock class which queries an internal rcl clock and exposes RosTime </summary>
+  /// <remarks>
+  /// Clock owns a standalone rcl_clock_t and is not registered with the global Ros2cs context.
+  /// It can continue returning time across Ros2cs Shutdown/Init cycles until disposed. The ROS clock
+  /// uses ROS 2 clock semantics: without an active simulation clock source, it falls back to system time.
+  /// </remarks>
   public class Clock : IExtendedDisposable
   {
     /// <summary>Number of nanoseconds in one second, used for lossless normalization.</summary>

--- a/src/ros2cs/ros2cs_core/Node.cs
+++ b/src/ros2cs/ros2cs_core/Node.cs
@@ -17,6 +17,7 @@
 // - Added child entity disposal contract for node-owned resources.
 // - Disposes child entities before node shutdown and aggregates errors.
 // - Removes entities even when disposal throws.
+// - Added default node option allocation failure handling.
 
 using System;
 using System.Linq;
@@ -98,7 +99,20 @@ namespace ROS2
 
       nodeHandle = NativeRcl.rcl_get_zero_initialized_node();
       defaultNodeOptions = NativeRclInterface.rclcs_node_create_default_options();
-      Utils.CheckReturnEnum(NativeRcl.rcl_node_init(ref nodeHandle, nodeName, nodeNamespace, ref context, defaultNodeOptions));
+      if (defaultNodeOptions == IntPtr.Zero)
+      {
+        throw new RuntimeError("Failed to create node options");
+      }
+      try
+      {
+        Utils.CheckReturnEnum(NativeRcl.rcl_node_init(ref nodeHandle, nodeName, nodeNamespace, ref context, defaultNodeOptions));
+      }
+      catch
+      {
+        NativeRclInterface.rclcs_node_dispose_options(defaultNodeOptions);
+        defaultNodeOptions = IntPtr.Zero;
+        throw;
+      }
       logger.LogInfo("Node initialized");
     }
 

--- a/src/ros2cs/ros2cs_core/Node.cs
+++ b/src/ros2cs/ros2cs_core/Node.cs
@@ -19,6 +19,7 @@
 // - Removes entities even when disposal throws.
 // - Added default node option allocation failure handling.
 // - Removed redundant DestroyNode alias in favor of Dispose.
+// - Made node disposal state volatile for child entity shutdown visibility.
 
 using System;
 using System.Linq;
@@ -81,7 +82,9 @@ namespace ROS2
     private HashSet<IClientBase> clients;
     private HashSet<IServiceBase> services;
     private readonly object mutex = new object();
-    private bool disposed = false;
+    // Child entities read this outside node.mutex while holding their own mutex. Volatile preserves
+    // visibility after rcl_node_fini without reversing the node -> child disposal lock order.
+    private volatile bool disposed = false;
 
     public bool IsDisposed { get { return disposed; } }
 

--- a/src/ros2cs/ros2cs_core/Node.cs
+++ b/src/ros2cs/ros2cs_core/Node.cs
@@ -1,4 +1,5 @@
 // Copyright 2019-2021 Robotec.ai
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,12 +13,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Modifications by Jianbin Liu:
+// - Added child entity disposal contract for node-owned resources.
+// - Disposes child entities before node shutdown and aggregates errors.
+// - Removes entities even when disposal throws.
+
 using System;
 using System.Linq;
 using System.Collections.Generic;
 
 namespace ROS2
 {
+  /// <summary>Internal contract for entities whose native handles are owned by a node.</summary>
+  internal interface INodeChildEntity : IDisposable
+  {
+    /// <summary>Dispose from the owning node without recursively removing the entity from that node.</summary>
+    void DisposeFromNode(bool disposing);
+  }
+
   /// <summary> Represents a managed ros2 (rcl) node </summary>
   /// <see cref="INode"/>
   public class Node: INode
@@ -92,53 +105,146 @@ namespace ROS2
     /// <summary> Finalizer supporting IDisposable model </summary>
     ~Node()
     {
-      DestroyNode();
+      Dispose(false);
     }
 
     /// <summary> Release managed and native resources. IDisposable implementation </summary>
     public void Dispose()
     {
-      DestroyNode();
+      Dispose(true);
+      GC.SuppressFinalize(this);
     }
 
     /// <summary> "Destructor" supporting IDisposable model </summary>
     /// <description> Disposes all subscriptions and publishers and clients before finilizing node </description>
     internal void DestroyNode()
     {
+      Dispose();
+    }
+
+    /// <summary>Shared node disposal path used by explicit disposal and the finalizer.</summary>
+    private void Dispose(bool disposing)
+    {
       lock (mutex)
       {
-        if (!disposed)
+        if (disposed)
         {
-          foreach(ISubscriptionBase subscription in subscriptions)
-          {
-            subscription.Dispose();
-          }
-          subscriptions.Clear();
+          return;
+        }
 
-          foreach(IPublisherBase publisher in publishers)
-          {
-            publisher.Dispose();
-          }
-          publishers.Clear();
+        List<Exception> exceptions = null;
 
-          foreach(IClientBase client in clients)
-          {
-            client.Dispose();
-          }
-          clients.Clear();
+        // Even finalizer cleanup must fini children before rcl_node_fini; rcl does not cascade this.
+        DisposeChildren(subscriptions, disposing, ref exceptions);
+        subscriptions.Clear();
 
-          foreach(IServiceBase service in services)
-          {
-            service.Dispose();
-          }
-          services.Clear();
+        DisposeChildren(publishers, disposing, ref exceptions);
+        publishers.Clear();
 
-          Utils.CheckReturnEnum(NativeRcl.rcl_node_fini(ref nodeHandle));
-          NativeRclInterface.rclcs_node_dispose_options(defaultNodeOptions);
-          disposed = true;
+        DisposeChildren(clients, disposing, ref exceptions);
+        clients.Clear();
+
+        DisposeChildren(services, disposing, ref exceptions);
+        services.Clear();
+
+        try
+        {
+          int ret = NativeRcl.rcl_node_fini(ref nodeHandle);
+          if (disposing)
+          {
+            Utils.CheckReturnEnum(ret);
+          }
+        }
+        catch (Exception e)
+        {
+          if (disposing)
+          {
+            AddException(ref exceptions, e);
+          }
+        }
+        finally
+        {
+          try
+          {
+            if (defaultNodeOptions != IntPtr.Zero)
+            {
+              NativeRclInterface.rclcs_node_dispose_options(defaultNodeOptions);
+            }
+          }
+          catch (Exception e)
+          {
+            if (disposing)
+            {
+              AddException(ref exceptions, e);
+            }
+          }
+          finally
+          {
+            defaultNodeOptions = IntPtr.Zero;
+            disposed = true;
+          }
+        }
+
+        if (disposing)
+        {
           logger.LogInfo("Node " + name + " destroyed");
+          if (exceptions != null && exceptions.Count > 0)
+          {
+            throw new AggregateException(exceptions);
+          }
         }
       }
+    }
+
+    /// <summary>Copy live waitable entities into spin-local lists while holding the node lock.</summary>
+    internal void AppendEntities(
+      List<ISubscriptionBase> targetSubscriptions,
+      List<IClientBase> targetClients,
+      List<IServiceBase> targetServices)
+    {
+      lock (mutex)
+      {
+        targetSubscriptions.AddRange(subscriptions.Where(s => s != null));
+        targetClients.AddRange(clients.Where(c => c != null));
+        targetServices.AddRange(services.Where(s => s != null));
+      }
+    }
+
+    /// <summary>Dispose child entities and aggregate explicit-dispose failures.</summary>
+    private static void DisposeChildren<T>(IEnumerable<T> children, bool disposing, ref List<Exception> exceptions)
+      where T : IDisposable
+    {
+      foreach (T child in children.ToList())
+      {
+        try
+        {
+          if (child is INodeChildEntity nodeChild)
+          {
+            nodeChild.DisposeFromNode(disposing);
+          }
+          else if (disposing)
+          {
+            child.Dispose();
+          }
+        }
+        catch (Exception e)
+        {
+          if (disposing)
+          {
+            AddException(ref exceptions, e);
+          }
+        }
+      }
+    }
+
+    /// <summary>Lazy-create the exception collection used during coordinated shutdown.</summary>
+    private static void AddException(ref List<Exception> exceptions, Exception exception)
+    {
+      if (exceptions == null)
+      {
+        exceptions = new List<Exception>();
+      }
+      exceptions.Add(exception);
     }
 
     /// <summary> Create a client for this node for a given topic, qos and message type </summary>
@@ -168,8 +274,15 @@ namespace ROS2
         if (clients.Contains(client))
         {
           logger.LogInfo("Removing client for topic " + client.Topic);
-          client.Dispose();
-          return clients.Remove(client);
+          try
+          {
+            client.Dispose();
+          }
+          finally
+          {
+            clients.Remove(client);
+          }
+          return true;
         }
         return false;
       }
@@ -203,8 +316,15 @@ namespace ROS2
         if (services.Contains(service))
         {
           logger.LogInfo("Removing service for topic " + service.Topic);
-          service.Dispose();
-          return services.Remove(service);
+          try
+          {
+            service.Dispose();
+          }
+          finally
+          {
+            services.Remove(service);
+          }
+          return true;
         }
         return false;
       }
@@ -257,8 +377,15 @@ namespace ROS2
         if (publishers.Contains(publisher))
         {
           logger.LogInfo("Removing publisher for topic " + publisher.Topic);
-          publisher.Dispose();
-          return publishers.Remove(publisher);
+          try
+          {
+            publisher.Dispose();
+          }
+          finally
+          {
+            publishers.Remove(publisher);
+          }
+          return true;
         }
         return false;
       }
@@ -273,8 +400,15 @@ namespace ROS2
         if (subscriptions.Contains(subscription))
         {
           logger.LogInfo("Removing subscription for topic " + subscription.Topic);
-          subscription.Dispose();
-          return subscriptions.Remove(subscription);
+          try
+          {
+            subscription.Dispose();
+          }
+          finally
+          {
+            subscriptions.Remove(subscription);
+          }
+          return true;
         }
         return false;
       }

--- a/src/ros2cs/ros2cs_core/Node.cs
+++ b/src/ros2cs/ros2cs_core/Node.cs
@@ -18,6 +18,7 @@
 // - Disposes child entities before node shutdown and aggregates errors.
 // - Removes entities even when disposal throws.
 // - Added default node option allocation failure handling.
+// - Removed redundant DestroyNode alias in favor of Dispose.
 
 using System;
 using System.Linq;
@@ -127,13 +128,6 @@ namespace ROS2
     {
       Dispose(true);
       GC.SuppressFinalize(this);
-    }
-
-    /// <summary> "Destructor" supporting IDisposable model </summary>
-    /// <description> Disposes all subscriptions and publishers and clients before finilizing node </description>
-    internal void DestroyNode()
-    {
-      Dispose();
     }
 
     /// <summary>Shared node disposal path used by explicit disposal and the finalizer.</summary>

--- a/src/ros2cs/ros2cs_core/Node.cs
+++ b/src/ros2cs/ros2cs_core/Node.cs
@@ -20,6 +20,7 @@
 // - Added default node option allocation failure handling.
 // - Removed redundant DestroyNode alias in favor of Dispose.
 // - Made node disposal state volatile for child entity shutdown visibility.
+// - Propagates native node option finalization failures during explicit disposal.
 
 using System;
 using System.Linq;
@@ -111,10 +112,22 @@ namespace ROS2
       {
         Utils.CheckReturnEnum(NativeRcl.rcl_node_init(ref nodeHandle, nodeName, nodeNamespace, ref context, defaultNodeOptions));
       }
-      catch
+      catch (Exception initException)
       {
-        NativeRclInterface.rclcs_node_dispose_options(defaultNodeOptions);
-        defaultNodeOptions = IntPtr.Zero;
+        List<Exception> exceptions = new List<Exception> { initException };
+        try
+        {
+          Utils.CheckReturnEnum(NativeRclInterface.rclcs_node_dispose_options(defaultNodeOptions));
+        }
+        catch (Exception disposeException)
+        {
+          exceptions.Add(disposeException);
+        }
+        finally
+        {
+          defaultNodeOptions = IntPtr.Zero;
+        }
+        Utils.ThrowCollectedExceptions(exceptions);
         throw;
       }
       logger.LogInfo("Node initialized");
@@ -179,7 +192,7 @@ namespace ROS2
           {
             if (defaultNodeOptions != IntPtr.Zero)
             {
-              NativeRclInterface.rclcs_node_dispose_options(defaultNodeOptions);
+              Utils.CheckReturnEnum(NativeRclInterface.rclcs_node_dispose_options(defaultNodeOptions));
             }
           }
           catch (Exception e)

--- a/src/ros2cs/ros2cs_core/Node.cs
+++ b/src/ros2cs/ros2cs_core/Node.cs
@@ -247,17 +247,27 @@ namespace ROS2
       exceptions.Add(exception);
     }
 
+    /// <summary>Reject entity creation when the owning node or global context is no longer live.</summary>
+    private void ThrowIfCannotCreateEntity(string entityKind)
+    {
+      if (disposed)
+      {
+        throw new ObjectDisposedException(nameof(Node), "Cannot create " + entityKind + " as the node is already disposed");
+      }
+      if (!Ros2cs.Ok())
+      {
+        logger.LogWarning("Cannot create " + entityKind + " as shutdown was called");
+        throw new NotInitializedException();
+      }
+    }
+
     /// <summary> Create a client for this node for a given topic, qos and message type </summary>
     /// <see cref="INode.CreateClient"/>
     public Client<I, O> CreateClient<I, O>(string topic, QualityOfServiceProfile qos = null) where I : Message, new() where O : Message, new()
     {
       lock (mutex)
       {
-        if (disposed || !Ros2cs.Ok())
-        {
-          logger.LogWarning("Cannot create client as the class is already disposed or shutdown was called");
-          return null;
-        }
+        ThrowIfCannotCreateEntity("client");
 
         Client<I, O> client = new Client<I, O>(topic, this, qos);
         clients.Add(client);
@@ -294,13 +304,9 @@ namespace ROS2
     {
       lock (mutex)
       {
-        if (disposed || !Ros2cs.Ok())
-        {
-          logger.LogWarning("Cannot create service as the class is already disposed or shutdown was called");
-          return null;
-        }
+        ThrowIfCannotCreateEntity("service");
 
-	Service<I, O> service = new Service<I, O>(topic, this, callback, qos);
+        Service<I, O> service = new Service<I, O>(topic, this, callback, qos);
         services.Add(service);
         logger.LogInfo("Created service for topic " + topic);
         return service;
@@ -336,11 +342,7 @@ namespace ROS2
     {
       lock (mutex)
       {
-        if (disposed || !Ros2cs.Ok())
-        {
-          logger.LogWarning("Cannot create publisher as the class is already disposed or shutdown was called");
-          return null;
-        }
+        ThrowIfCannotCreateEntity("publisher");
 
         Publisher<T> publisher = new Publisher<T>(topic, this, qos);
         publishers.Add(publisher);
@@ -355,11 +357,7 @@ namespace ROS2
     {
       lock (mutex)
       {
-        if (disposed || !Ros2cs.Ok())
-        {
-          logger.LogWarning("Cannot create subscription as the class is already disposed or shutdown was called");
-          return null;
-        }
+        ThrowIfCannotCreateEntity("subscription");
 
         Subscription<T> subscription = new Subscription<T>(topic, this, callback, qos);
         subscriptions.Add(subscription);

--- a/src/ros2cs/ros2cs_core/Publisher.cs
+++ b/src/ros2cs/ros2cs_core/Publisher.cs
@@ -1,4 +1,5 @@
 // Copyright 2019-2021 Robotec.ai
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,23 +13,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Modifications by Jianbin Liu:
+// - Added node-owned disposal path.
+// - Added QoS/options cleanup and owning-node shutdown guards.
+
 using System;
-using System.Diagnostics;
 using ROS2.Internal;
 
 namespace ROS2
 {
-  /// <summary> Publisher of a topic with a given type </summary>
+  /// <summary> Publisher of a topic with a given type and node-owned native lifetime. </summary>
   /// <description> Publishers are created through INode.CreatePublisher </description>
-  public class Publisher<T>: IPublisher<T> where T : Message, new ()
+  public class Publisher<T>: IPublisher<T>, INodeChildEntity where T : Message, new ()
   {
     public string Topic { get { return topic; } }
     private string topic;
 
     private Ros2csLogger logger = Ros2csLogger.GetInstance();
-    rcl_publisher_t publisherHandle;
-    IntPtr publisherOptions = IntPtr.Zero;
-    rcl_node_t nodeHandle;
+    // Native publisher/options handles are finalized before the owning node is finalized.
+    private rcl_publisher_t publisherHandle;
+    private IntPtr publisherOptions = IntPtr.Zero;
+    // Keep the owning node reference so fini calls always use the current native node handle.
+    private readonly Node node;
+    private readonly object mutex = new object();
     private bool disposed = false;
 
     public bool IsDisposed { get { return disposed; } }
@@ -38,44 +45,134 @@ namespace ROS2
     public Publisher(string pubTopic, Node node, QualityOfServiceProfile qos = null)
     {
       topic = pubTopic;
-      nodeHandle = node.nodeHandle;
+      this.node = node;
 
       QualityOfServiceProfile qualityOfServiceProfile = qos;
+      bool ownsQos = false;
       if (qualityOfServiceProfile == null)
+      {
         qualityOfServiceProfile = new QualityOfServiceProfile();
+        ownsQos = true;
+      }
 
-      publisherOptions = NativeRclInterface.rclcs_publisher_create_options(qualityOfServiceProfile.handle);
+      try
+      {
+        publisherOptions = NativeRclInterface.rclcs_publisher_create_options(qualityOfServiceProfile.Handle);
+        if (publisherOptions == IntPtr.Zero)
+        {
+          throw new RuntimeError("Failed to create publisher options");
+        }
+      }
+      finally
+      {
+        if (ownsQos)
+        {
+          qualityOfServiceProfile.Dispose();
+        }
+      }
 
       IntPtr typeSupportHandle = MessageTypeSupportHelper.GetTypeSupportHandle<T>();
 
       publisherHandle = NativeRcl.rcl_get_zero_initialized_publisher();
-      Utils.CheckReturnEnum(NativeRcl.rcl_publisher_init(
-                              ref publisherHandle,
-                              ref nodeHandle,
-                              typeSupportHandle,
-                              topic,
-                              publisherOptions));
+      try
+      {
+        Utils.CheckReturnEnum(NativeRcl.rcl_publisher_init(
+                                ref publisherHandle,
+                                ref node.nodeHandle,
+                                typeSupportHandle,
+                                topic,
+                                publisherOptions));
+      }
+      catch
+      {
+        NativeRclInterface.rclcs_publisher_dispose_options(publisherOptions);
+        publisherOptions = IntPtr.Zero;
+        throw;
+      }
     }
 
     ~Publisher()
     {
-      Dispose();
+      Dispose(false);
     }
 
+    /// <summary>Release the publisher and its native options.</summary>
     public void Dispose()
     {
-      DestroyPublisher();
+      Dispose(true);
+      GC.SuppressFinalize(this);
     }
 
-    /// <summary> "Destructor" supporting disposable model </summary>
-    private void DestroyPublisher()
+    /// <summary>Release this publisher during node disposal without re-entering node removal.</summary>
+    void INodeChildEntity.DisposeFromNode(bool disposing)
     {
-      if (!disposed)
+      Dispose(disposing);
+      if (disposing)
       {
-        Utils.CheckReturnEnum(NativeRcl.rcl_publisher_fini(ref publisherHandle, ref nodeHandle));
-        NativeRclInterface.rclcs_publisher_dispose_options(publisherOptions);
+        GC.SuppressFinalize(this);
+      }
+    }
+
+    /// <summary>Shared publisher disposal path used by explicit disposal, node disposal, and finalization.</summary>
+    private void Dispose(bool disposing)
+    {
+      Exception disposeException = null;
+      lock (mutex)
+      {
+        if (disposed)
+        {
+          return;
+        }
+
+        try
+        {
+          if (!node.IsDisposed)
+          {
+            int ret = NativeRcl.rcl_publisher_fini(ref publisherHandle, ref node.nodeHandle);
+            if (disposing)
+            {
+              Utils.CheckReturnEnum(ret);
+            }
+          }
+        }
+        catch (Exception e)
+        {
+          if (disposing)
+          {
+            disposeException = e;
+          }
+        }
+        finally
+        {
+          try
+          {
+            if (publisherOptions != IntPtr.Zero)
+            {
+              NativeRclInterface.rclcs_publisher_dispose_options(publisherOptions);
+            }
+          }
+          catch (Exception e)
+          {
+            if (disposing && disposeException == null)
+            {
+              disposeException = e;
+            }
+          }
+          finally
+          {
+            publisherOptions = IntPtr.Zero;
+            disposed = true;
+          }
+        }
+      }
+
+      if (disposing)
+      {
         logger.LogInfo("Publisher destroyed");
-        disposed = true;
+        if (disposeException != null)
+        {
+          throw disposeException;
+        }
       }
     }
 
@@ -83,14 +180,24 @@ namespace ROS2
     /// <see cref="IPublisher.Publish"/>
     public void Publish(T msg)
     {
-      if (!Ros2cs.Ok() || disposed)
+      lock (mutex)
       {
-        logger.LogWarning("Cannot publish as the class is already disposed or shutdown was called");
-        return;
+        if (!Ros2cs.Ok() || disposed)
+        {
+          logger.LogWarning("Cannot publish as the class is already disposed or shutdown was called");
+          return;
+        }
+        if (node.IsDisposed)
+        {
+          // Publishing after node disposal would pass an invalid rcl node-owned handle.
+          logger.LogWarning("Cannot publish as the owning node is already disposed");
+          return;
+        }
+
+        MessageInternals msgInternals = MessageTypeSupportHelper.AsMessageInternals(msg, nameof(msg));
+        msgInternals.WriteNativeMessage();
+        Utils.CheckReturnEnum(NativeRcl.rcl_publish(ref publisherHandle, msgInternals.Handle, IntPtr.Zero));
       }
-      MessageInternals msgInternals = msg as MessageInternals;
-      msgInternals.WriteNativeMessage();
-      Utils.CheckReturnEnum(NativeRcl.rcl_publish(ref publisherHandle, msgInternals.Handle, IntPtr.Zero));
     }
   }
 }

--- a/src/ros2cs/ros2cs_core/Publisher.cs
+++ b/src/ros2cs/ros2cs_core/Publisher.cs
@@ -16,6 +16,7 @@
 // Modifications by Jianbin Liu:
 // - Added node-owned disposal path.
 // - Added QoS/options cleanup and owning-node shutdown guards.
+// - Restricted construction to node factory methods.
 
 using System;
 using ROS2.Internal;
@@ -42,7 +43,7 @@ namespace ROS2
 
     /// <summary> Internal constructor for Publsher. Use INode.CreatePublisher to construct </summary>
     /// <see cref="INode.CreatePublisher"/>
-    public Publisher(string pubTopic, Node node, QualityOfServiceProfile qos = null)
+    internal Publisher(string pubTopic, Node node, QualityOfServiceProfile qos = null)
     {
       topic = pubTopic;
       this.node = node;

--- a/src/ros2cs/ros2cs_core/Publisher.cs
+++ b/src/ros2cs/ros2cs_core/Publisher.cs
@@ -19,6 +19,7 @@
 // - Restricted construction to node factory methods.
 
 using System;
+using System.Collections.Generic;
 using ROS2.Internal;
 
 namespace ROS2
@@ -117,7 +118,7 @@ namespace ROS2
     /// <summary>Shared publisher disposal path used by explicit disposal, node disposal, and finalization.</summary>
     private void Dispose(bool disposing)
     {
-      Exception disposeException = null;
+      List<Exception> disposeExceptions = null;
       lock (mutex)
       {
         if (disposed)
@@ -140,7 +141,7 @@ namespace ROS2
         {
           if (disposing)
           {
-            disposeException = e;
+            Utils.AddException(ref disposeExceptions, e);
           }
         }
         finally
@@ -154,9 +155,9 @@ namespace ROS2
           }
           catch (Exception e)
           {
-            if (disposing && disposeException == null)
+            if (disposing)
             {
-              disposeException = e;
+              Utils.AddException(ref disposeExceptions, e);
             }
           }
           finally
@@ -170,10 +171,7 @@ namespace ROS2
       if (disposing)
       {
         logger.LogInfo("Publisher destroyed");
-        if (disposeException != null)
-        {
-          throw disposeException;
-        }
+        Utils.ThrowCollectedExceptions(disposeExceptions);
       }
     }
 

--- a/src/ros2cs/ros2cs_core/Publisher.cs
+++ b/src/ros2cs/ros2cs_core/Publisher.cs
@@ -17,6 +17,7 @@
 // - Added node-owned disposal path.
 // - Added QoS/options cleanup and owning-node shutdown guards.
 // - Restricted construction to node factory methods.
+// - Made disposal state volatile for node/entity visibility.
 
 using System;
 using System.Collections.Generic;
@@ -38,7 +39,7 @@ namespace ROS2
     // Keep the owning node reference so fini calls always use the current native node handle.
     private readonly Node node;
     private readonly object mutex = new object();
-    private bool disposed = false;
+    private volatile bool disposed = false;
 
     public bool IsDisposed { get { return disposed; } }
 

--- a/src/ros2cs/ros2cs_core/QualityOfServiceProfile.cs
+++ b/src/ros2cs/ros2cs_core/QualityOfServiceProfile.cs
@@ -66,6 +66,7 @@ namespace ROS2
   {
     // Native rmw_qos_profile_t wrapper owned by this managed object.
     internal IntPtr handle;
+    private readonly object mutex = new object();
     private bool disposed;
 
     /// <summary>Native QoS profile handle, guarded against use after disposal.</summary>
@@ -73,8 +74,11 @@ namespace ROS2
     {
       get
       {
-        ThrowIfDisposed();
-        return handle;
+        lock (mutex)
+        {
+          ThrowIfDisposed();
+          return handle;
+        }
       }
     }
 
@@ -90,20 +94,29 @@ namespace ROS2
 
     public void SetHistory(HistoryPolicy policy, int depth)
     {
-      ThrowIfDisposed();
-      NativeRmwInterface.rmw_native_interface_set_history(handle, (int)policy, depth);
+      lock (mutex)
+      {
+        ThrowIfDisposed();
+        NativeRmwInterface.rmw_native_interface_set_history(handle, (int)policy, depth);
+      }
     }
 
     public void SetReliability(ReliabilityPolicy policy)
     {
-      ThrowIfDisposed();
-      NativeRmwInterface.rmw_native_interface_set_reliability(handle, (int)policy);
+      lock (mutex)
+      {
+        ThrowIfDisposed();
+        NativeRmwInterface.rmw_native_interface_set_reliability(handle, (int)policy);
+      }
     }
 
     public void SetDurability(DurabilityPolicy policy)
     {
-      ThrowIfDisposed();
-      NativeRmwInterface.rmw_native_interface_set_durability(handle, (int)policy);
+      lock (mutex)
+      {
+        ThrowIfDisposed();
+        NativeRmwInterface.rmw_native_interface_set_durability(handle, (int)policy);
+      }
     }
 
     /// <summary>Release the native QoS profile wrapper.</summary>
@@ -121,35 +134,38 @@ namespace ROS2
     /// <summary>Shared QoS disposal path used by explicit disposal and the finalizer.</summary>
     private void Dispose(bool disposing)
     {
-      Exception disposeException = null;
-      if (disposed)
+      lock (mutex)
       {
-        return;
-      }
-
-      try
-      {
-        if (handle != IntPtr.Zero)
+        Exception disposeException = null;
+        if (disposed)
         {
-          NativeRmwInterface.rmw_native_interface_delete_qos_profile(handle);
+          return;
         }
-      }
-      catch (Exception e)
-      {
-        if (disposing)
-        {
-          disposeException = e;
-        }
-      }
-      finally
-      {
-        handle = IntPtr.Zero;
-        disposed = true;
-      }
 
-      if (disposeException != null)
-      {
-        throw disposeException;
+        try
+        {
+          if (handle != IntPtr.Zero)
+          {
+            NativeRmwInterface.rmw_native_interface_delete_qos_profile(handle);
+          }
+        }
+        catch (Exception e)
+        {
+          if (disposing)
+          {
+            disposeException = e;
+          }
+        }
+        finally
+        {
+          handle = IntPtr.Zero;
+          disposed = true;
+        }
+
+        if (disposeException != null)
+        {
+          throw disposeException;
+        }
       }
     }
 

--- a/src/ros2cs/ros2cs_core/QualityOfServiceProfile.cs
+++ b/src/ros2cs/ros2cs_core/QualityOfServiceProfile.cs
@@ -121,6 +121,7 @@ namespace ROS2
     /// <summary>Shared QoS disposal path used by explicit disposal and the finalizer.</summary>
     private void Dispose(bool disposing)
     {
+      Exception disposeException = null;
       if (disposed)
       {
         return;
@@ -133,13 +134,22 @@ namespace ROS2
           NativeRmwInterface.rmw_native_interface_delete_qos_profile(handle);
         }
       }
-      catch
+      catch (Exception e)
       {
+        if (disposing)
+        {
+          disposeException = e;
+        }
       }
       finally
       {
         handle = IntPtr.Zero;
         disposed = true;
+      }
+
+      if (disposeException != null)
+      {
+        throw disposeException;
       }
     }
 

--- a/src/ros2cs/ros2cs_core/QualityOfServiceProfile.cs
+++ b/src/ros2cs/ros2cs_core/QualityOfServiceProfile.cs
@@ -1,4 +1,5 @@
 // Copyright 2019-2021 Robotec.ai
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// Modifications by Jianbin Liu:
+// - Made QoS profiles disposable.
+// - Added native handle validation before QoS mutation.
 
 using System;
 
@@ -57,29 +62,94 @@ namespace ROS2
   }
 
   /// <summary> Quality of Service settings for publishers and subscriptions </summary>
-  public class QualityOfServiceProfile
+  public class QualityOfServiceProfile : IDisposable
   {
+    // Native rmw_qos_profile_t wrapper owned by this managed object.
     internal IntPtr handle;
+    private bool disposed;
+
+    /// <summary>Native QoS profile handle, guarded against use after disposal.</summary>
+    internal IntPtr Handle
+    {
+      get
+      {
+        ThrowIfDisposed();
+        return handle;
+      }
+    }
 
     /// <summary> Construct using a preset </summary>
     public QualityOfServiceProfile(QosPresetProfile preset_profile = QosPresetProfile.DEFAULT)
     {
       handle = NativeRmwInterface.rmw_native_interface_create_qos_profile((int)preset_profile);
+      if (handle == IntPtr.Zero)
+      {
+        throw new RuntimeError("Failed to create QoS profile");
+      }
     }
 
     public void SetHistory(HistoryPolicy policy, int depth)
     {
+      ThrowIfDisposed();
       NativeRmwInterface.rmw_native_interface_set_history(handle, (int)policy, depth);
     }
 
     public void SetReliability(ReliabilityPolicy policy)
     {
+      ThrowIfDisposed();
       NativeRmwInterface.rmw_native_interface_set_reliability(handle, (int)policy);
     }
 
     public void SetDurability(DurabilityPolicy policy)
     {
+      ThrowIfDisposed();
       NativeRmwInterface.rmw_native_interface_set_durability(handle, (int)policy);
+    }
+
+    /// <summary>Release the native QoS profile wrapper.</summary>
+    public void Dispose()
+    {
+      Dispose(true);
+      GC.SuppressFinalize(this);
+    }
+
+    ~QualityOfServiceProfile()
+    {
+      Dispose(false);
+    }
+
+    /// <summary>Shared QoS disposal path used by explicit disposal and the finalizer.</summary>
+    private void Dispose(bool disposing)
+    {
+      if (disposed)
+      {
+        return;
+      }
+
+      try
+      {
+        if (handle != IntPtr.Zero)
+        {
+          NativeRmwInterface.rmw_native_interface_delete_qos_profile(handle);
+        }
+      }
+      catch
+      {
+      }
+      finally
+      {
+        handle = IntPtr.Zero;
+        disposed = true;
+      }
+    }
+
+    /// <summary>Reject mutations after the native QoS profile has been released.</summary>
+    private void ThrowIfDisposed()
+    {
+      if (disposed)
+      {
+        throw new ObjectDisposedException(nameof(QualityOfServiceProfile));
+      }
     }
   }
 }

--- a/src/ros2cs/ros2cs_core/Ros2cs.cs
+++ b/src/ros2cs/ros2cs_core/Ros2cs.cs
@@ -1,4 +1,5 @@
 // Copyright 2019-2021 Robotec.ai
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +12,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// Modifications by Jianbin Liu:
+// - Added coordinated shutdown of nodes, wait set, and rcl context.
+// - Added spin callback tracking to prevent synchronous call reentry.
+// - Serialized wait set access and reduced reconnect/spin noise.
 
 using System;
 using System.Linq;
@@ -31,12 +37,25 @@ namespace ROS2
   {
     private static readonly Destructor destructor = new Destructor();
     private static readonly object mutex = new object();
+    // Wait set access is serialized separately so shutdown cannot race a spin wait.
+    private static readonly object waitSetMutex = new object();
+    [ThreadStatic]
+    // Tracks callback execution per spinning thread to reject deadlock-prone synchronous client calls.
+    private static int spinCallbackDepth;
     private static bool initialized = false;  // for most part equivalent to rcl::ok()
+    // Prevents rcl_context_fini from running twice across explicit shutdown and finalization.
+    private static bool contextFinalized = true;
     private static rcl_context_t global_context;  // a simplification, we only use global default context
     private static rcl_allocator_t default_allocator;
     private static List<INode> nodes = new List<INode>(); // kept to shutdown everything in order
 
     private static WaitSet WaitSet;
+
+    /// <summary>Whether the current thread is executing subscription/client/service callbacks.</summary>
+    internal static bool IsInSpinCallback
+    {
+      get { return spinCallbackDepth > 0; }
+    }
 
     /// <summary> Globally initialize ros2 (rcl) </summary>
     /// <description> Note that only a single context is used. </description>
@@ -56,6 +75,7 @@ namespace ROS2
         Utils.CheckReturnEnum(NativeRclInterface.rclcs_init(ref global_context, default_allocator));
         WaitSet = new WaitSet(ref global_context);
         initialized = true;
+        contextFinalized = false;
       }
     }
 
@@ -70,6 +90,7 @@ namespace ROS2
     /// </description>
     public static void Shutdown()
     {
+      List<Exception> exceptions = null;
       lock (mutex)
       {
         if (!initialized)
@@ -79,13 +100,60 @@ namespace ROS2
         initialized = false;
 
         Ros2csLogger.GetInstance().LogInfo("Ros2cs shutdown");
-        Utils.CheckReturnEnum(NativeRcl.rcl_shutdown(ref global_context));
 
+        // Dispose nodes before rcl_shutdown so child handles can finalize against a valid context.
         foreach (var node in nodes)
         {
-          node.Dispose();
+          try
+          {
+            node.Dispose();
+          }
+          catch (Exception e)
+          {
+            AddException(ref exceptions, e);
+          }
         }
         nodes.Clear();
+
+        // The wait set must be released while no SpinOnce call can mutate or wait on it.
+        lock (waitSetMutex)
+        {
+          try
+          {
+            if (WaitSet != null)
+            {
+              WaitSet.Dispose();
+              WaitSet = null;
+            }
+          }
+          catch (Exception e)
+          {
+            AddException(ref exceptions, e);
+          }
+        }
+
+        try
+        {
+          Utils.CheckReturnEnum(NativeRcl.rcl_shutdown(ref global_context));
+        }
+        catch (Exception e)
+        {
+          AddException(ref exceptions, e);
+        }
+
+        try
+        {
+          FiniContext(true);
+        }
+        catch (Exception e)
+        {
+          AddException(ref exceptions, e);
+        }
+      }
+
+      if (exceptions != null && exceptions.Count > 0)
+      {
+        throw new AggregateException(exceptions);
       }
     }
 
@@ -105,9 +173,14 @@ namespace ROS2
     {
       ~Destructor()
       {
-        Ros2csLogger.GetInstance().LogInfo("Ros2cs destructor called");
-        Ros2cs.Shutdown();
-        NativeRcl.rcl_context_fini(ref global_context);
+        try
+        {
+          Ros2cs.Shutdown();
+          FiniContext(false);
+        }
+        catch
+        {
+        }
       }
     }
 
@@ -159,8 +232,15 @@ namespace ROS2
         {
           return false; // removal is handled with shutdown already
         }
-        node.Dispose();
-        return nodes.Remove(node);
+        try
+        {
+          node.Dispose();
+        }
+        finally
+        {
+          nodes.Remove(node);
+        }
+        return true;
       }
     }
 
@@ -195,7 +275,7 @@ namespace ROS2
     /// <summary> Spin only once </summary>
     /// <description> This overload is meant for when the while loop is better to
     /// handle in the application layer  </description>
-    /// <returns> Whether the spin was successful (wait set not empty or Ros2cs not initialized) </returns>
+    /// <returns> Whether the wait set was populated and waited on. Timeout with entities returns true. </returns>
     /// <see cref="Spin(INode,double)"/>
     public static bool SpinOnce(INode node, double timeoutSec = 0.1)
     {
@@ -203,37 +283,45 @@ namespace ROS2
       return SpinOnce(nodes, timeoutSec);
     }
 
-    private static bool warned_once = false;
-
     /// <summary> SpinOnce overload for multiple nodes </summary>
     /// <remarks> This overload saves on implicit List creation </remarks>
-    /// <returns> Whether the spin was successful (wait set not empty or Ros2cs not initialized) </returns>
+    /// <returns> Whether the wait set was populated and waited on. Timeout with entities returns true. </returns>
     /// <see cref="SpinOnce(INode,double)"/>
     public static bool SpinOnce(List<INode> nodes, double timeoutSec = 0.1)
     {
+      List<ISubscriptionBase> allSubscriptions;
+      List<IClientBase> allClients;
+      List<IServiceBase> allServices;
+      bool success;
+
       lock (mutex)
-      {  // Figure out how to minimize this lock
+      {
         if (!initialized)
         {
           return false;
         }
 
-        // TODO - This can be optimized so that we cache the list and invalidate only with changes
-        var allSubscriptions = new List<ISubscriptionBase>();
-        var allClients = new List<IClientBase>();
-        var allServices = new List<IServiceBase>();
+        // Snapshot entity collections under the global/node locks, then release them before waiting.
+        allSubscriptions = new List<ISubscriptionBase>();
+        allClients = new List<IClientBase>();
+        allServices = new List<IServiceBase>();
         foreach (INode node_interface in nodes)
         {
           Node node = node_interface as Node;
           if (node == null)
             continue; //Rare situation in which we are disposing
-          
-          allSubscriptions.AddRange(node.Subscriptions.Where(s => s != null));
-          allClients.AddRange(node.Clients.Where(c => c != null));
-          allServices.AddRange(node.Services.Where(s => s != null));
+
+          node.AppendEntities(allSubscriptions, allClients, allServices);
+        }
+      }
+
+      lock (waitSetMutex)
+      {
+        if (!initialized || WaitSet == null)
+        {
+          return false;
         }
 
-        // TODO - investigate performance impact
         WaitSet.Resize(
           (ulong)allSubscriptions.Count,
           (ulong)allClients.Count,
@@ -254,7 +342,6 @@ namespace ROS2
           AddResult result = WaitSet.TryAddService(service, out ulong _);
           Debug.Assert(result != AddResult.FULL, "no space for Service in WaitSet");
         }
-        bool success;
         try
         {
           success = WaitSet.Wait(TimeSpan.FromSeconds(timeoutSec));
@@ -263,15 +350,51 @@ namespace ROS2
         {
           return false;
         }
-        if (success)
+      }
+
+      if (success)
+      {
+        // Mark callback execution so synchronous client calls can fail fast instead of blocking spin.
+        spinCallbackDepth++;
+        try
         {
           // Sequential processing
           allSubscriptions.ForEach(subscription => subscription.TakeMessage());
           allClients.ForEach(client => client.TakeMessage());
           allServices.ForEach(service => service.TakeMessage());
         }
-        return true;
+        finally
+        {
+          spinCallbackDepth--;
+        }
       }
+      return true;
+    }
+
+    /// <summary>Finalize the global rcl context exactly once.</summary>
+    private static void FiniContext(bool throwing)
+    {
+      if (contextFinalized)
+      {
+        return;
+      }
+
+      int ret = NativeRcl.rcl_context_fini(ref global_context);
+      contextFinalized = true;
+      if (throwing)
+      {
+        Utils.CheckReturnEnum(ret);
+      }
+    }
+
+    /// <summary>Lazy-create the exception collection used by coordinated shutdown.</summary>
+    private static void AddException(ref List<Exception> exceptions, Exception exception)
+    {
+      if (exceptions == null)
+      {
+        exceptions = new List<Exception>();
+      }
+      exceptions.Add(exception);
     }
   }
 }

--- a/src/ros2cs/ros2cs_core/Ros2cs.cs
+++ b/src/ros2cs/ros2cs_core/Ros2cs.cs
@@ -17,6 +17,7 @@
 // - Added coordinated shutdown of nodes, wait set, and rcl context.
 // - Added spin callback tracking to prevent synchronous call reentry.
 // - Serialized wait set access and reduced reconnect/spin noise.
+// - Suppressed the static shutdown finalizer after explicit Shutdown.
 
 using System;
 using System.Linq;
@@ -50,6 +51,7 @@ namespace ROS2
     private static List<INode> nodes = new List<INode>(); // kept to shutdown everything in order
 
     private static WaitSet WaitSet;
+    private static bool destructorFinalizerSuppressed;
 
     /// <summary>Whether the current thread is executing subscription/client/service callbacks.</summary>
     internal static bool IsInSpinCallback
@@ -76,6 +78,11 @@ namespace ROS2
         WaitSet = new WaitSet(ref global_context);
         initialized = true;
         contextFinalized = false;
+        if (destructorFinalizerSuppressed)
+        {
+          GC.ReRegisterForFinalize(destructor);
+          destructorFinalizerSuppressed = false;
+        }
       }
     }
 
@@ -97,6 +104,7 @@ namespace ROS2
         {
           return;
         }
+        SuppressDestructorFinalizer();
         initialized = false;
 
         Ros2csLogger.GetInstance().LogInfo("Ros2cs shutdown");
@@ -182,6 +190,18 @@ namespace ROS2
         {
         }
       }
+    }
+
+    /// <summary>Prevent the static finalizer from re-entering Shutdown after explicit shutdown starts.</summary>
+    private static void SuppressDestructorFinalizer()
+    {
+      if (destructorFinalizerSuppressed)
+      {
+        return;
+      }
+
+      GC.SuppressFinalize(destructor);
+      destructorFinalizerSuppressed = true;
     }
 
     /// <summary> Create a ros2 (rcl) node </summary>

--- a/src/ros2cs/ros2cs_core/Ros2cs.cs
+++ b/src/ros2cs/ros2cs_core/Ros2cs.cs
@@ -18,6 +18,7 @@
 // - Added spin callback tracking to prevent synchronous call reentry.
 // - Serialized wait set access and reduced reconnect/spin noise.
 // - Suppressed the static shutdown finalizer after explicit Shutdown.
+// - Clarified context and wait-set lifecycle invariants.
 
 using System;
 using System.Linq;
@@ -39,13 +40,14 @@ namespace ROS2
     private static readonly object mutex = new object();
     // Guards native context validation/finalization without participating in node lock ordering.
     private static readonly object contextMutex = new object();
-    // Wait set access is serialized separately so shutdown cannot race a spin wait.
+    // Wait set access is serialized separately so shutdown waits for at most the active SpinOnce timeout.
     private static readonly object waitSetMutex = new object();
     [ThreadStatic]
     // Tracks callback execution per spinning thread to reject deadlock-prone synchronous client calls.
     private static int spinCallbackDepth;
     private static volatile bool initialized = false;  // for most part equivalent to rcl::ok()
-    // Prevents rcl_context_fini from running twice across explicit shutdown and finalization.
+    // true before first Init() so FiniContext() is a no-op in the pre-init state.
+    // After Init(), it prevents rcl_context_fini from running twice across shutdown/finalization.
     private static bool contextFinalized = true;
     private static rcl_context_t global_context;  // a simplification, we only use global default context
     private static rcl_allocator_t default_allocator;
@@ -175,11 +177,6 @@ namespace ROS2
     /// </description>
     public static bool Ok()
     {
-      if (!initialized)
-      {
-        return false;
-      }
-
       lock (contextMutex)
       {
         return initialized && !contextFinalized && NativeRcl.rcl_context_is_valid(ref global_context);
@@ -280,7 +277,8 @@ namespace ROS2
     /// application layer since it runs in a blocking infinite loop. Will return when some work is
     /// executed (a callback for each subscription that received a message) or after a timeout.
     /// Note that you don't need to spin if you are only publishing (like in ros2) </description>
-    /// <remarks> Only subscriptions are executed currently, no timers or other executables </remarks>
+    /// <remarks> Only subscriptions are executed currently, no timers or other executables.
+    /// Shutdown waits for an in-flight spin wait to return, so shutdown latency can be up to timeoutSec. </remarks>
     /// <param name="node"> A node to spin on </param>
     /// <param name="timoutSec"> Maximum time to wait for execution item (e. g. subscription) </param>
     public static void Spin(INode node, double timeoutSec = 0.1)
@@ -290,7 +288,8 @@ namespace ROS2
     }
 
     /// <summary> Spin overload for multiple nodes </summary>
-    /// <remarks> This overload saves on implicit List creation </remarks>
+    /// <remarks> This overload saves on implicit List creation. Shutdown waits for an in-flight
+    /// spin wait to return, so shutdown latency can be up to timeoutSec. </remarks>
     /// <see cref="Spin(INode,double)"/>
     public static void Spin(List<INode> nodes, double timeoutSec = 0.1)
     {
@@ -315,7 +314,8 @@ namespace ROS2
     }
 
     /// <summary> SpinOnce overload for multiple nodes </summary>
-    /// <remarks> This overload saves on implicit List creation </remarks>
+    /// <remarks> This overload saves on implicit List creation. Shutdown waits for an in-flight
+    /// spin wait to return, so shutdown latency can be up to timeoutSec. </remarks>
     /// <returns> Whether the wait set was populated and waited on. Timeout with entities returns true. </returns>
     /// <see cref="SpinOnce(INode,double)"/>
     public static bool SpinOnce(List<INode> nodes, double timeoutSec = 0.1)

--- a/src/ros2cs/ros2cs_core/Ros2cs.cs
+++ b/src/ros2cs/ros2cs_core/Ros2cs.cs
@@ -19,6 +19,7 @@
 // - Serialized wait set access and reduced reconnect/spin noise.
 // - Suppressed the static shutdown finalizer after explicit Shutdown.
 // - Clarified context and wait-set lifecycle invariants.
+// - Pruned directly disposed nodes before enforcing name uniqueness.
 
 using System;
 using System.Linq;
@@ -231,6 +232,7 @@ namespace ROS2
           throw new NotInitializedException();
         }
 
+        nodes.RemoveAll(node => node.IsDisposed);
         foreach (var node in nodes)
         {
           if (node.Name == nodeName)

--- a/src/ros2cs/ros2cs_core/Ros2cs.cs
+++ b/src/ros2cs/ros2cs_core/Ros2cs.cs
@@ -21,7 +21,6 @@
 
 using System;
 using System.Linq;
-using System.Diagnostics;
 using System.Collections.Generic;
 using System.Threading;
 
@@ -197,7 +196,6 @@ namespace ROS2
         try
         {
           Ros2cs.Shutdown();
-          FiniContext(false);
         }
         catch
         {
@@ -363,17 +361,17 @@ namespace ROS2
         foreach(var subscription in allSubscriptions)
         {
           AddResult result = WaitSet.TryAddSubscription(subscription, out ulong _);
-          Debug.Assert(result != AddResult.FULL, "no space for subscription in WaitSet");
+          ThrowIfWaitSetFull(result, "subscription");
         }
         foreach(var client in allClients)
         {
           AddResult result = WaitSet.TryAddClient(client, out ulong _);
-          Debug.Assert(result != AddResult.FULL, "no space for client in WaitSet");
+          ThrowIfWaitSetFull(result, "client");
         }
         foreach(var service in allServices)
         {
           AddResult result = WaitSet.TryAddService(service, out ulong _);
-          Debug.Assert(result != AddResult.FULL, "no space for Service in WaitSet");
+          ThrowIfWaitSetFull(result, "service");
         }
         try
         {
@@ -443,6 +441,15 @@ namespace ROS2
       {
         Ros2csLogger.GetInstance().LogError(
           "Unhandled exception while processing " + entityKind + " '" + topic + "': " + e);
+      }
+    }
+
+    /// <summary>Fail explicitly when a resized wait set cannot accept all collected entities.</summary>
+    private static void ThrowIfWaitSetFull(AddResult result, string entityType)
+    {
+      if (result == AddResult.FULL)
+      {
+        throw new InvalidOperationException("No space for " + entityType + " in WaitSet");
       }
     }
 

--- a/src/ros2cs/ros2cs_core/Ros2cs.cs
+++ b/src/ros2cs/ros2cs_core/Ros2cs.cs
@@ -38,12 +38,14 @@ namespace ROS2
   {
     private static readonly Destructor destructor = new Destructor();
     private static readonly object mutex = new object();
+    // Guards native context validation/finalization without participating in node lock ordering.
+    private static readonly object contextMutex = new object();
     // Wait set access is serialized separately so shutdown cannot race a spin wait.
     private static readonly object waitSetMutex = new object();
     [ThreadStatic]
     // Tracks callback execution per spinning thread to reject deadlock-prone synchronous client calls.
     private static int spinCallbackDepth;
-    private static bool initialized = false;  // for most part equivalent to rcl::ok()
+    private static volatile bool initialized = false;  // for most part equivalent to rcl::ok()
     // Prevents rcl_context_fini from running twice across explicit shutdown and finalization.
     private static bool contextFinalized = true;
     private static rcl_context_t global_context;  // a simplification, we only use global default context
@@ -72,12 +74,15 @@ namespace ROS2
           return;
         }
 
-        default_allocator = NativeRcl.rcutils_get_default_allocator();
-        global_context = NativeRcl.rcl_get_zero_initialized_context();
-        Utils.CheckReturnEnum(NativeRclInterface.rclcs_init(ref global_context, default_allocator));
-        WaitSet = new WaitSet(ref global_context);
-        initialized = true;
-        contextFinalized = false;
+        lock (contextMutex)
+        {
+          default_allocator = NativeRcl.rcutils_get_default_allocator();
+          global_context = NativeRcl.rcl_get_zero_initialized_context();
+          Utils.CheckReturnEnum(NativeRclInterface.rclcs_init(ref global_context, default_allocator));
+          WaitSet = new WaitSet(ref global_context);
+          initialized = true;
+          contextFinalized = false;
+        }
         if (destructorFinalizerSuppressed)
         {
           GC.ReRegisterForFinalize(destructor);
@@ -171,7 +176,15 @@ namespace ROS2
     /// </description>
     public static bool Ok()
     {
-      return initialized && NativeRcl.rcl_context_is_valid(ref global_context);
+      if (!initialized)
+      {
+        return false;
+      }
+
+      lock (contextMutex)
+      {
+        return initialized && !contextFinalized && NativeRcl.rcl_context_is_valid(ref global_context);
+      }
     }
 
     /// <summary> Helper class to handle Ros2cs finalization </summary>
@@ -378,10 +391,19 @@ namespace ROS2
         spinCallbackDepth++;
         try
         {
-          // Sequential processing
-          allSubscriptions.ForEach(subscription => subscription.TakeMessage());
-          allClients.ForEach(client => client.TakeMessage());
-          allServices.ForEach(service => service.TakeMessage());
+          // Sequential processing. Isolate each entity so one user callback cannot stop the whole batch.
+          foreach (ISubscriptionBase subscription in allSubscriptions)
+          {
+            TryTakeMessage(subscription.TakeMessage, "subscription", subscription.Topic);
+          }
+          foreach (IClientBase client in allClients)
+          {
+            TryTakeMessage(client.TakeMessage, "client", client.Topic);
+          }
+          foreach (IServiceBase service in allServices)
+          {
+            TryTakeMessage(service.TakeMessage, "service", service.Topic);
+          }
         }
         finally
         {
@@ -394,16 +416,33 @@ namespace ROS2
     /// <summary>Finalize the global rcl context exactly once.</summary>
     private static void FiniContext(bool throwing)
     {
-      if (contextFinalized)
+      lock (contextMutex)
       {
-        return;
-      }
+        if (contextFinalized)
+        {
+          return;
+        }
 
-      int ret = NativeRcl.rcl_context_fini(ref global_context);
-      contextFinalized = true;
-      if (throwing)
+        int ret = NativeRcl.rcl_context_fini(ref global_context);
+        contextFinalized = true;
+        if (throwing)
+        {
+          Utils.CheckReturnEnum(ret);
+        }
+      }
+    }
+
+    /// <summary>Run one waitable callback path without letting user exceptions abort the spin batch.</summary>
+    private static void TryTakeMessage(Action action, string entityKind, string topic)
+    {
+      try
       {
-        Utils.CheckReturnEnum(ret);
+        action();
+      }
+      catch (Exception e)
+      {
+        Ros2csLogger.GetInstance().LogError(
+          "Unhandled exception while processing " + entityKind + " '" + topic + "': " + e);
       }
     }
 

--- a/src/ros2cs/ros2cs_core/Service.cs
+++ b/src/ros2cs/ros2cs_core/Service.cs
@@ -17,6 +17,7 @@
 // - Added node-owned disposal path and options cleanup.
 // - Suppressed stale client response noise during shutdown/reconnect.
 // - Added safe request message disposal.
+// - Isolated user callback exceptions from native response handling.
 
 using System;
 using System.Collections.Generic;
@@ -52,6 +53,7 @@ namespace ROS2
     /// Callback to be called to process incoming requests
     /// </summary>
     private readonly Func<I, O> callback;
+    private readonly Ros2csLogger logger = Ros2csLogger.GetInstance();
     // Native service options are released with the service, including constructor failure paths.
     private IntPtr serviceOptions = IntPtr.Zero;
 
@@ -205,7 +207,17 @@ namespace ROS2
     private void ProcessRequest(rcl_rmw_request_id_t header, MessageInternals message)
     {
       message.ReadNativeMessage();
-      O response = callback((I)message);
+      O response = null;
+      try
+      {
+        response = callback((I)message);
+      }
+      catch (Exception e)
+      {
+        logger.LogError("Unhandled exception in service callback for topic '" + topic + "': " + e);
+        return;
+      }
+
       try
       {
         SendResp(header, response);

--- a/src/ros2cs/ros2cs_core/Service.cs
+++ b/src/ros2cs/ros2cs_core/Service.cs
@@ -207,7 +207,7 @@ namespace ROS2
     private void ProcessRequest(rcl_rmw_request_id_t header, MessageInternals message)
     {
       message.ReadNativeMessage();
-      O response = null;
+      O response = default(O);
       try
       {
         response = callback((I)message);

--- a/src/ros2cs/ros2cs_core/Service.cs
+++ b/src/ros2cs/ros2cs_core/Service.cs
@@ -18,6 +18,7 @@
 // - Suppressed stale client response noise during shutdown/reconnect.
 // - Added safe request message disposal.
 // - Isolated user callback exceptions from native response handling.
+// - Made disposal state volatile for node/entity visibility.
 
 using System;
 using System.Collections.Generic;
@@ -44,7 +45,7 @@ namespace ROS2
 
     /// <inheritdoc/>
     public bool IsDisposed { get { return disposed; } }
-    private bool disposed = false;
+    private volatile bool disposed = false;
 
     // Keep the owning node reference so fini calls always use the current native node handle.
     private readonly Node node;

--- a/src/ros2cs/ros2cs_core/Service.cs
+++ b/src/ros2cs/ros2cs_core/Service.cs
@@ -19,6 +19,7 @@
 // - Added safe request message disposal.
 
 using System;
+using System.Collections.Generic;
 using ROS2.Internal;
 
 namespace ROS2
@@ -139,7 +140,7 @@ namespace ROS2
     }
 
     /// <inheritdoc/>
-    // TODO(adamdbrw) this should not be public - add an internal interface
+    // Internal spin entry point; kept public through IServiceBase for compatibility.
     public void TakeMessage()
     {
       RCLReturnEnum ret;
@@ -205,7 +206,17 @@ namespace ROS2
     {
       message.ReadNativeMessage();
       O response = callback((I)message);
-      SendResp(header, response);
+      try
+      {
+        SendResp(header, response);
+      }
+      finally
+      {
+        if (!object.ReferenceEquals(response, message))
+        {
+          response?.Dispose();
+        }
+      }
     }
 
     ~Service()
@@ -233,7 +244,7 @@ namespace ROS2
     /// <summary>Shared service disposal path used by explicit disposal, node disposal, and finalization.</summary>
     private void Dispose(bool disposing)
     {
-      Exception disposeException = null;
+      List<Exception> disposeExceptions = null;
       lock (mutex)
       {
         if (disposed)
@@ -256,7 +267,7 @@ namespace ROS2
         {
           if (disposing)
           {
-            disposeException = e;
+            Utils.AddException(ref disposeExceptions, e);
           }
         }
         finally
@@ -270,9 +281,9 @@ namespace ROS2
           }
           catch (Exception e)
           {
-            if (disposing && disposeException == null)
+            if (disposing)
             {
-              disposeException = e;
+              Utils.AddException(ref disposeExceptions, e);
             }
           }
           finally
@@ -286,10 +297,7 @@ namespace ROS2
       if (disposing)
       {
         Ros2csLogger.GetInstance().LogInfo("Service destroyed");
-        if (disposeException != null)
-        {
-          throw disposeException;
-        }
+        Utils.ThrowCollectedExceptions(disposeExceptions);
       }
     }
   }

--- a/src/ros2cs/ros2cs_core/Service.cs
+++ b/src/ros2cs/ros2cs_core/Service.cs
@@ -1,4 +1,5 @@
 // Copyright 2019-2021 Robotec.ai
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,16 +13,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Modifications by Jianbin Liu:
+// - Added node-owned disposal path and options cleanup.
+// - Suppressed stale client response noise during shutdown/reconnect.
+// - Added safe request message disposal.
+
 using System;
 using ROS2.Internal;
 
 namespace ROS2
 {
-    /// <summary>Service with a topic and Types for Messages</summary>
+    /// <summary>Service with a topic, message types, and node-owned native lifetime.</summary>
     /// <remarks>Instances are created by <see cref="INode.CreateService"/></remarks>
     /// <typeparam name="I">Message Type to be received</typeparam>
     /// <typeparam name="O">Message Type to be send</typeparam>
-    public class Service<I, O>: IService<I, O>
+    public class Service<I, O>: IService<I, O>, INodeChildEntity
     where I : Message, new ()
     where O : Message, new ()
   {
@@ -38,14 +44,15 @@ namespace ROS2
     public bool IsDisposed { get { return disposed; } }
     private bool disposed = false;
 
-    /// <inheritdoc/>
-    private rcl_node_t nodeHandle;
+    // Keep the owning node reference so fini calls always use the current native node handle.
+    private readonly Node node;
 
     /// <summary>
     /// Callback to be called to process incoming requests
     /// </summary>
     private readonly Func<I, O> callback;
-    private IntPtr serviceOptions;
+    // Native service options are released with the service, including constructor failure paths.
+    private IntPtr serviceOptions = IntPtr.Zero;
 
     /// <inheritdoc/>
     public object Mutex { get { return mutex; } }
@@ -58,29 +65,51 @@ namespace ROS2
     internal Service(string subTopic, Node node, Func<I, O> cb, QualityOfServiceProfile qos = null)
     {
       callback = cb;
-      nodeHandle = node.nodeHandle;
+      this.node = node;
       topic = subTopic;
       serviceHandle = NativeRcl.rcl_get_zero_initialized_service();
 
       QualityOfServiceProfile qualityOfServiceProfile = qos;
+      bool ownsQos = false;
       if (qualityOfServiceProfile == null)
       {
         qualityOfServiceProfile = new QualityOfServiceProfile(QosPresetProfile.SERVICES_DEFAULT);
+        ownsQos = true;
       }
 
-      serviceOptions = NativeRclInterface.rclcs_service_create_options(qualityOfServiceProfile.handle);
+      try
+      {
+        serviceOptions = NativeRclInterface.rclcs_service_create_options(qualityOfServiceProfile.Handle);
+        if (serviceOptions == IntPtr.Zero)
+        {
+          throw new RuntimeError("Failed to create service options");
+        }
+      }
+      finally
+      {
+        if (ownsQos)
+        {
+          qualityOfServiceProfile.Dispose();
+        }
+      }
 
-      I msg = new I();
-      MessageInternals msgInternals = msg as MessageInternals;
-      IntPtr typeSupportHandle = msgInternals.TypeSupportHandle;
-      msg.Dispose();
+      IntPtr typeSupportHandle = MessageTypeSupportHelper.GetTypeSupportHandle<I>();
 
-      Utils.CheckReturnEnum(NativeRcl.rcl_service_init(
-        ref serviceHandle,
-        ref node.nodeHandle,
-        typeSupportHandle,
-        topic,
-        serviceOptions));
+      try
+      {
+        Utils.CheckReturnEnum(NativeRcl.rcl_service_init(
+          ref serviceHandle,
+          ref node.nodeHandle,
+          typeSupportHandle,
+          topic,
+          serviceOptions));
+      }
+      catch
+      {
+        NativeRclInterface.rclcs_service_dispose_options(serviceOptions);
+        serviceOptions = IntPtr.Zero;
+        throw;
+      }
     }
 
     /// <summary>
@@ -90,10 +119,23 @@ namespace ROS2
     /// <param name="msg">Message to be send</param>
     private void SendResp(rcl_rmw_request_id_t header, O msg)
     {
-      RCLReturnEnum ret;
-      MessageInternals msgInternals = msg as MessageInternals;
+      MessageInternals msgInternals = MessageTypeSupportHelper.AsMessageInternals(msg, nameof(msg));
       msgInternals.WriteNativeMessage();
-      ret = (RCLReturnEnum)NativeRcl.rcl_send_response(ref serviceHandle, ref header, msgInternals.Handle);
+      int ret = NativeRcl.rcl_send_response(ref serviceHandle, ref header, msgInternals.Handle);
+      if ((RCLReturnEnum)ret == RCLReturnEnum.RCL_RET_OK)
+      {
+        return;
+      }
+
+      string errorMessage = Utils.PopRclErrorString();
+      if (errorMessage != null &&
+          errorMessage.IndexOf("client will not receive response", StringComparison.Ordinal) >= 0)
+      {
+        // Late responses can occur during reconnect/shutdown; rcl reports them even though no fix is needed.
+        return;
+      }
+
+      Utils.ThrowRclException(ret, errorMessage);
     }
 
     /// <inheritdoc/>
@@ -102,7 +144,7 @@ namespace ROS2
     {
       RCLReturnEnum ret;
       rcl_rmw_request_id_t header = default(rcl_rmw_request_id_t);
-      MessageInternals message;
+      MessageInternals message = null;
 
       lock (mutex)
       {
@@ -110,14 +152,46 @@ namespace ROS2
         {
           return;
         }
-        message = new I() as MessageInternals;
+        message = CreateMessage();
 
-        ret = (RCLReturnEnum)NativeRcl.rcl_take_request(ref serviceHandle, ref header,  message.Handle);
+        ret = (RCLReturnEnum)NativeRcl.rcl_take_request(ref serviceHandle, ref header, message.Handle);
       }
 
-      if ((RCLReturnEnum)ret == RCLReturnEnum.RCL_RET_OK)
+      if (ret == RCLReturnEnum.RCL_RET_SERVICE_TAKE_FAILED)
+      {
+        ((IDisposable)message).Dispose();
+        return;
+      }
+
+      if (ret != RCLReturnEnum.RCL_RET_OK)
+      {
+        ((IDisposable)message).Dispose();
+        Utils.CheckReturnEnum((int)ret);
+        return;
+      }
+
+      try
       {
         ProcessRequest(header, message);
+      }
+      finally
+      {
+        ((IDisposable)message).Dispose();
+      }
+    }
+
+    /// <summary>Create a request message and validate its native-message interface.</summary>
+    private MessageInternals CreateMessage()
+    {
+      I msg = new I();
+      try
+      {
+        return MessageTypeSupportHelper.AsMessageInternals(msg, nameof(msg));
+      }
+      catch
+      {
+        msg.Dispose();
+        throw;
       }
     }
 
@@ -136,25 +210,85 @@ namespace ROS2
 
     ~Service()
     {
-      DestroyService();
+      Dispose(false);
     }
 
+    /// <summary>Release the service and its native options.</summary>
     public void Dispose()
     {
-      DestroyService();
+      Dispose(true);
+      GC.SuppressFinalize(this);
     }
 
-    /// <summary> "Destructor" supporting disposable model </summary>
-    private void DestroyService()
+    /// <summary>Release this service during node disposal without re-entering node removal.</summary>
+    void INodeChildEntity.DisposeFromNode(bool disposing)
     {
+      Dispose(disposing);
+      if (disposing)
+      {
+        GC.SuppressFinalize(this);
+      }
+    }
+
+    /// <summary>Shared service disposal path used by explicit disposal, node disposal, and finalization.</summary>
+    private void Dispose(bool disposing)
+    {
+      Exception disposeException = null;
       lock (mutex)
       {
-        if (!disposed)
+        if (disposed)
         {
-          Utils.CheckReturnEnum(NativeRcl.rcl_service_fini(ref serviceHandle, ref nodeHandle));
-          NativeRclInterface.rclcs_node_dispose_options(serviceOptions);
-          disposed = true;
-          Ros2csLogger.GetInstance().LogInfo("Service destroyed");
+          return;
+        }
+
+        try
+        {
+          if (!node.IsDisposed)
+          {
+            int ret = NativeRcl.rcl_service_fini(ref serviceHandle, ref node.nodeHandle);
+            if (disposing)
+            {
+              Utils.CheckReturnEnum(ret);
+            }
+          }
+        }
+        catch (Exception e)
+        {
+          if (disposing)
+          {
+            disposeException = e;
+          }
+        }
+        finally
+        {
+          try
+          {
+            if (serviceOptions != IntPtr.Zero)
+            {
+              NativeRclInterface.rclcs_service_dispose_options(serviceOptions);
+            }
+          }
+          catch (Exception e)
+          {
+            if (disposing && disposeException == null)
+            {
+              disposeException = e;
+            }
+          }
+          finally
+          {
+            serviceOptions = IntPtr.Zero;
+            disposed = true;
+          }
+        }
+      }
+
+      if (disposing)
+      {
+        Ros2csLogger.GetInstance().LogInfo("Service destroyed");
+        if (disposeException != null)
+        {
+          throw disposeException;
         }
       }
     }

--- a/src/ros2cs/ros2cs_core/Subscription.cs
+++ b/src/ros2cs/ros2cs_core/Subscription.cs
@@ -16,6 +16,7 @@
 // Modifications by Jianbin Liu:
 // - Added node-owned disposal path and options cleanup.
 // - Added safe message disposal and take-failure handling.
+// - Propagates native subscription option finalization failures during explicit disposal.
 
 using System;
 using System.Collections.Generic;
@@ -154,10 +155,22 @@ namespace ROS2
           topic,
           subscriptionOptions));
       }
-      catch
+      catch (Exception initException)
       {
-        NativeRclInterface.rclcs_subscription_dispose_options(subscriptionOptions);
-        subscriptionOptions = IntPtr.Zero;
+        List<Exception> exceptions = new List<Exception> { initException };
+        try
+        {
+          Utils.CheckReturnEnum(NativeRclInterface.rclcs_subscription_dispose_options(subscriptionOptions));
+        }
+        catch (Exception disposeException)
+        {
+          exceptions.Add(disposeException);
+        }
+        finally
+        {
+          subscriptionOptions = IntPtr.Zero;
+        }
+        Utils.ThrowCollectedExceptions(exceptions);
         throw;
       }
     }
@@ -219,7 +232,7 @@ namespace ROS2
           {
             if (subscriptionOptions != IntPtr.Zero)
             {
-              NativeRclInterface.rclcs_subscription_dispose_options(subscriptionOptions);
+              Utils.CheckReturnEnum(NativeRclInterface.rclcs_subscription_dispose_options(subscriptionOptions));
             }
           }
           catch (Exception e)

--- a/src/ros2cs/ros2cs_core/Subscription.cs
+++ b/src/ros2cs/ros2cs_core/Subscription.cs
@@ -17,6 +17,7 @@
 // - Added node-owned disposal path and options cleanup.
 // - Added safe message disposal and take-failure handling.
 // - Propagates native subscription option finalization failures during explicit disposal.
+// - Made disposal state volatile for node/entity visibility.
 
 using System;
 using System.Collections.Generic;
@@ -35,7 +36,7 @@ namespace ROS2
     private string topic;
 
     public bool IsDisposed { get { return disposed; } }
-    private bool disposed = false;
+    private volatile bool disposed = false;
 
     // Keep the owning node reference so fini calls always use the current native node handle.
     private readonly Node node;

--- a/src/ros2cs/ros2cs_core/Subscription.cs
+++ b/src/ros2cs/ros2cs_core/Subscription.cs
@@ -1,4 +1,5 @@
 // Copyright 2019-2021 Robotec.ai
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,14 +13,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Modifications by Jianbin Liu:
+// - Added node-owned disposal path and options cleanup.
+// - Added safe message disposal and take-failure handling.
+
 using System;
 using ROS2.Internal;
 
 namespace ROS2
 {
-  /// <summary> Subscription to a topic with a given type </summary>
+  /// <summary> Subscription to a topic with a given type and node-owned native lifetime. </summary>
   /// <description> Subscriptions are created through INode interface (CreateSubscription) </description>
-  public class Subscription<T>: ISubscription<T> where T : Message, new ()
+  public class Subscription<T>: ISubscription<T>, INodeChildEntity where T : Message, new ()
   {
     public rcl_subscription_t Handle { get { return subscriptionHandle; } }
     private rcl_subscription_t subscriptionHandle;
@@ -30,9 +35,11 @@ namespace ROS2
     public bool IsDisposed { get { return disposed; } }
     private bool disposed = false;
 
-    private rcl_node_t nodeHandle;
+    // Keep the owning node reference so fini calls always use the current native node handle.
+    private readonly Node node;
     private readonly Action<T> callback;
-    private IntPtr subscriptionOptions;
+    // Native subscription options are released with the subscription, including constructor failure paths.
+    private IntPtr subscriptionOptions = IntPtr.Zero;
 
     public object Mutex { get { return mutex; } }
     private object mutex = new object();
@@ -41,8 +48,9 @@ namespace ROS2
     // TODO(adamdbrw) this should not be public - add an internal interface
     public void TakeMessage()
     {
+      MessageInternals message = null;
       RCLReturnEnum ret;
-      MessageInternals message;
+
       lock (mutex)
       {
         if (disposed || !Ros2cs.Ok())
@@ -54,18 +62,43 @@ namespace ROS2
         ret = (RCLReturnEnum)NativeRcl.rcl_take(ref subscriptionHandle, message.Handle, IntPtr.Zero, IntPtr.Zero);
       }
 
-      bool gotMessage = ret == RCLReturnEnum.RCL_RET_OK;
+      if (ret == RCLReturnEnum.RCL_RET_SUBSCRIPTION_TAKE_FAILED)
+      {
+        // No message was available after wait; dispose the temporary wrapper quietly.
+        ((IDisposable)message).Dispose();
+        return;
+      }
 
-      if (gotMessage)
+      if (ret != RCLReturnEnum.RCL_RET_OK)
+      {
+        ((IDisposable)message).Dispose();
+        Utils.CheckReturnEnum((int)ret);
+        return;
+      }
+
+      try
       {
         TriggerCallback(message);
       }
+      finally
+      {
+        ((IDisposable)message).Dispose();
+      }
     }
 
-    /// <summary> Construct a message of the subscription type </summary>
+    /// <summary> Construct a message of the subscription type and validate its native-message interface. </summary>
     private MessageInternals CreateMessage()
     {
-      return new T() as MessageInternals;
+      T msg = new T();
+      try
+      {
+        return MessageTypeSupportHelper.AsMessageInternals(msg, nameof(msg));
+      }
+      catch
+      {
+        msg.Dispose();
+        throw;
+      }
     }
 
     /// <summary> Populates managed fields with native values and calls the callback with created message </summary>
@@ -81,52 +114,134 @@ namespace ROS2
     internal Subscription(string subTopic, Node node, Action<T> cb, QualityOfServiceProfile qos = null)
     {
       callback = cb;
-      nodeHandle = node.nodeHandle;
+      this.node = node;
       topic = subTopic;
       subscriptionHandle = NativeRcl.rcl_get_zero_initialized_subscription();
 
       QualityOfServiceProfile qualityOfServiceProfile = qos;
+      bool ownsQos = false;
       if (qualityOfServiceProfile == null)
       {
         qualityOfServiceProfile = new QualityOfServiceProfile();
+        ownsQos = true;
       }
 
-      subscriptionOptions = NativeRclInterface.rclcs_subscription_create_options(qualityOfServiceProfile.handle);
+      try
+      {
+        subscriptionOptions = NativeRclInterface.rclcs_subscription_create_options(qualityOfServiceProfile.Handle);
+        if (subscriptionOptions == IntPtr.Zero)
+        {
+          throw new RuntimeError("Failed to create subscription options");
+        }
+      }
+      finally
+      {
+        if (ownsQos)
+        {
+          qualityOfServiceProfile.Dispose();
+        }
+      }
 
-      T msg = new T();
-      MessageInternals msgInternals = msg as MessageInternals;
-      IntPtr typeSupportHandle = msgInternals.TypeSupportHandle;
-      msg.Dispose();
+      IntPtr typeSupportHandle = MessageTypeSupportHelper.GetTypeSupportHandle<T>();
 
-      Utils.CheckReturnEnum(NativeRcl.rcl_subscription_init(
-        ref subscriptionHandle,
-        ref node.nodeHandle,
-        typeSupportHandle,
-        topic,
-        subscriptionOptions));
+      try
+      {
+        Utils.CheckReturnEnum(NativeRcl.rcl_subscription_init(
+          ref subscriptionHandle,
+          ref node.nodeHandle,
+          typeSupportHandle,
+          topic,
+          subscriptionOptions));
+      }
+      catch
+      {
+        NativeRclInterface.rclcs_subscription_dispose_options(subscriptionOptions);
+        subscriptionOptions = IntPtr.Zero;
+        throw;
+      }
     }
 
     ~Subscription()
     {
-      DestroySubscription();
+      Dispose(false);
     }
 
+    /// <summary>Release the subscription and its native options.</summary>
     public void Dispose()
     {
-      DestroySubscription();
+      Dispose(true);
+      GC.SuppressFinalize(this);
     }
 
-    /// <summary> "Destructor" supporting disposable model </summary>
-    private void DestroySubscription()
+    /// <summary>Release this subscription during node disposal without re-entering node removal.</summary>
+    void INodeChildEntity.DisposeFromNode(bool disposing)
     {
+      Dispose(disposing);
+      if (disposing)
+      {
+        GC.SuppressFinalize(this);
+      }
+    }
+
+    /// <summary>Shared subscription disposal path used by explicit disposal, node disposal, and finalization.</summary>
+    private void Dispose(bool disposing)
+    {
+      Exception disposeException = null;
       lock (mutex)
       {
-        if (!disposed)
+        if (disposed)
         {
-          Utils.CheckReturnEnum(NativeRcl.rcl_subscription_fini(ref subscriptionHandle, ref nodeHandle));
-          NativeRclInterface.rclcs_node_dispose_options(subscriptionOptions);
-          disposed = true;
-          Ros2csLogger.GetInstance().LogInfo("Subscription destroyed");
+          return;
+        }
+
+        try
+        {
+          if (!node.IsDisposed)
+          {
+            int ret = NativeRcl.rcl_subscription_fini(ref subscriptionHandle, ref node.nodeHandle);
+            if (disposing)
+            {
+              Utils.CheckReturnEnum(ret);
+            }
+          }
+        }
+        catch (Exception e)
+        {
+          if (disposing)
+          {
+            disposeException = e;
+          }
+        }
+        finally
+        {
+          try
+          {
+            if (subscriptionOptions != IntPtr.Zero)
+            {
+              NativeRclInterface.rclcs_subscription_dispose_options(subscriptionOptions);
+            }
+          }
+          catch (Exception e)
+          {
+            if (disposing && disposeException == null)
+            {
+              disposeException = e;
+            }
+          }
+          finally
+          {
+            subscriptionOptions = IntPtr.Zero;
+            disposed = true;
+          }
+        }
+      }
+
+      if (disposing)
+      {
+        Ros2csLogger.GetInstance().LogInfo("Subscription destroyed");
+        if (disposeException != null)
+        {
+          throw disposeException;
         }
       }
     }

--- a/src/ros2cs/ros2cs_core/Subscription.cs
+++ b/src/ros2cs/ros2cs_core/Subscription.cs
@@ -18,6 +18,7 @@
 // - Added safe message disposal and take-failure handling.
 
 using System;
+using System.Collections.Generic;
 using ROS2.Internal;
 
 namespace ROS2
@@ -45,7 +46,7 @@ namespace ROS2
     private object mutex = new object();
 
     /// <summary> Tries to get a message from rcl/rmw layers. Calls the callback if successful </summary>
-    // TODO(adamdbrw) this should not be public - add an internal interface
+    // Internal spin entry point; kept public through ISubscriptionBase for compatibility.
     public void TakeMessage()
     {
       MessageInternals message = null;
@@ -186,7 +187,7 @@ namespace ROS2
     /// <summary>Shared subscription disposal path used by explicit disposal, node disposal, and finalization.</summary>
     private void Dispose(bool disposing)
     {
-      Exception disposeException = null;
+      List<Exception> disposeExceptions = null;
       lock (mutex)
       {
         if (disposed)
@@ -209,7 +210,7 @@ namespace ROS2
         {
           if (disposing)
           {
-            disposeException = e;
+            Utils.AddException(ref disposeExceptions, e);
           }
         }
         finally
@@ -223,9 +224,9 @@ namespace ROS2
           }
           catch (Exception e)
           {
-            if (disposing && disposeException == null)
+            if (disposing)
             {
-              disposeException = e;
+              Utils.AddException(ref disposeExceptions, e);
             }
           }
           finally
@@ -239,10 +240,7 @@ namespace ROS2
       if (disposing)
       {
         Ros2csLogger.GetInstance().LogInfo("Subscription destroyed");
-        if (disposeException != null)
-        {
-          throw disposeException;
-        }
+        Utils.ThrowCollectedExceptions(disposeExceptions);
       }
     }
   }

--- a/src/ros2cs/ros2cs_core/WaitSet.cs
+++ b/src/ros2cs/ros2cs_core/WaitSet.cs
@@ -17,6 +17,7 @@
 // - Made wait set lifetime disposable.
 // - Added disposed-state checks for spin and entity registration.
 // - Removed the unused wrapper Clear method; resizing is the active spin path.
+// - Removed the unused unbounded wait overload.
 
 using System;
 
@@ -31,6 +32,10 @@ namespace ROS2
   }
 
   /// <summary>Disposable wrapper around rcl_wait_set_t used by Ros2cs spinning.</summary>
+  /// <remarks>
+  /// Ros2cs serializes public spin/shutdown paths with its wait-set mutex. This wrapper keeps
+  /// its own mutex as a local ownership guard for finalizer cleanup and future internal callers.
+  /// </remarks>
   internal class WaitSet : IDisposable
   {
     internal ulong SubscriptionCount {get { return Handle.size_of_subscriptions.ToUInt64(); }}
@@ -247,11 +252,6 @@ namespace ROS2
           return AddResult.SUCCESS;
         }
       }
-    }
-
-    internal bool Wait()
-    {
-      return Wait(TimeSpan.FromTicks(-1));
     }
 
     internal bool Wait(TimeSpan timeout)

--- a/src/ros2cs/ros2cs_core/WaitSet.cs
+++ b/src/ros2cs/ros2cs_core/WaitSet.cs
@@ -1,4 +1,5 @@
 // Copyright 2019-2021 Robotec.ai
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Modifications by Jianbin Liu:
+// - Made wait set lifetime disposable.
+// - Added disposed-state checks for spin and entity registration.
+
 using System;
 
 namespace ROS2
@@ -20,10 +25,12 @@ namespace ROS2
   {
     SUCCESS,
     FULL,
+    // The wait set or target entity was disposed before it could be registered.
     DISPOSED
   }
 
-  internal class WaitSet
+  /// <summary>Disposable wrapper around rcl_wait_set_t used by Ros2cs spinning.</summary>
+  internal class WaitSet : IDisposable
   {
     internal ulong SubscriptionCount {get { return Handle.size_of_subscriptions.ToUInt64(); }}
 
@@ -32,6 +39,7 @@ namespace ROS2
     internal ulong ServiceCount {get { return Handle.size_of_services.ToUInt64(); }}
 
     private rcl_wait_set_t Handle;
+    private bool disposed;
 
     internal WaitSet(ref rcl_context_t context)
     {
@@ -50,16 +58,55 @@ namespace ROS2
 
     ~WaitSet()
     {
-      Utils.CheckReturnEnum(NativeRcl.rcl_wait_set_fini(ref Handle));
+      Dispose(false);
+    }
+
+    /// <summary>Release the native wait set.</summary>
+    public void Dispose()
+    {
+      Dispose(true);
+      GC.SuppressFinalize(this);
+    }
+
+    /// <summary>Shared wait set disposal path used by explicit disposal and the finalizer.</summary>
+    private void Dispose(bool disposing)
+    {
+      // Explicit shutdown disposes this internal type under Ros2cs waitSetMutex; finalizer cleanup is best-effort.
+      if (disposed)
+      {
+        return;
+      }
+
+      try
+      {
+        int ret = NativeRcl.rcl_wait_set_fini(ref Handle);
+        if (disposing)
+        {
+          Utils.CheckReturnEnum(ret);
+        }
+      }
+      catch
+      {
+        if (disposing)
+        {
+          throw;
+        }
+      }
+      finally
+      {
+        disposed = true;
+      }
     }
 
     internal void Clear()
     {
+      ThrowIfDisposed();
       Utils.CheckReturnEnum(NativeRcl.rcl_wait_set_clear(ref Handle));
     }
 
     internal void Resize(ulong subscriptionCount, ulong clientCount, ulong serviceCount)
     {
+      ThrowIfDisposed();
       Utils.CheckReturnEnum(NativeRcl.rcl_wait_set_resize(
       ref Handle,
       (UIntPtr)subscriptionCount,
@@ -72,8 +119,15 @@ namespace ROS2
 
     internal AddResult TryAddSubscription(ISubscriptionBase subscription, out ulong index)
     {
+      if (disposed)
+      {
+        index = default(ulong);
+        return AddResult.DISPOSED;
+      }
+
       UIntPtr native_index = default(UIntPtr);
       int ret;
+      // Entity locks prevent Dispose from finalizing handles while they are being registered.
       lock (subscription.Mutex)
       {
         if (subscription.IsDisposed)
@@ -105,8 +159,15 @@ namespace ROS2
 
     internal AddResult TryAddClient(IClientBase client, out ulong index)
     {
+      if (disposed)
+      {
+        index = default(ulong);
+        return AddResult.DISPOSED;
+      }
+
       UIntPtr native_index = default(UIntPtr);
       int ret;
+      // Entity locks prevent Dispose from finalizing handles while they are being registered.
       lock (client.Mutex)
       {
         if (client.IsDisposed)
@@ -138,9 +199,16 @@ namespace ROS2
 
     internal AddResult TryAddService(IServiceBase service, out ulong index)
     {
+      if (disposed)
+      {
+        index = default(ulong);
+        return AddResult.DISPOSED;
+      }
+
       UIntPtr native_index = default(UIntPtr);
       int ret;
 
+      // Entity locks prevent Dispose from finalizing handles while they are being registered.
       lock (service.Mutex)
       {
         if (service.IsDisposed)
@@ -178,6 +246,7 @@ namespace ROS2
 
     internal bool Wait(TimeSpan timeout)
     {
+      ThrowIfDisposed();
       int ret = NativeRcl.rcl_wait(ref Handle, timeout.Ticks * 100);
       if ((RCLReturnEnum)ret == RCLReturnEnum.RCL_RET_TIMEOUT)
       {
@@ -187,6 +256,15 @@ namespace ROS2
       {
         Utils.CheckReturnEnum(ret);
         return true;
+      }
+    }
+
+    /// <summary>Reject wait set operations after shutdown has released the native handle.</summary>
+    private void ThrowIfDisposed()
+    {
+      if (disposed)
+      {
+        throw new ObjectDisposedException(nameof(WaitSet));
       }
     }
   }

--- a/src/ros2cs/ros2cs_core/WaitSet.cs
+++ b/src/ros2cs/ros2cs_core/WaitSet.cs
@@ -40,6 +40,7 @@ namespace ROS2
     internal ulong ServiceCount {get { return Handle.size_of_services.ToUInt64(); }}
 
     private rcl_wait_set_t Handle;
+    private readonly object mutex = new object();
     private bool disposed;
 
     internal WaitSet(ref rcl_context_t context)
@@ -72,165 +73,179 @@ namespace ROS2
     /// <summary>Shared wait set disposal path used by explicit disposal and the finalizer.</summary>
     private void Dispose(bool disposing)
     {
-      // Explicit shutdown disposes this internal type under Ros2cs waitSetMutex; finalizer cleanup is best-effort.
-      if (disposed)
+      lock (mutex)
       {
-        return;
-      }
+        // Explicit shutdown disposes this internal type under Ros2cs waitSetMutex; finalizer cleanup is best-effort.
+        if (disposed)
+        {
+          return;
+        }
 
-      try
-      {
-        int ret = NativeRcl.rcl_wait_set_fini(ref Handle);
-        if (disposing)
+        try
         {
-          Utils.CheckReturnEnum(ret);
+          int ret = NativeRcl.rcl_wait_set_fini(ref Handle);
+          if (disposing)
+          {
+            Utils.CheckReturnEnum(ret);
+          }
         }
-      }
-      catch
-      {
-        if (disposing)
+        catch
         {
-          throw;
+          if (disposing)
+          {
+            throw;
+          }
         }
-      }
-      finally
-      {
-        disposed = true;
+        finally
+        {
+          disposed = true;
+        }
       }
     }
 
     internal void Resize(ulong subscriptionCount, ulong clientCount, ulong serviceCount)
     {
-      ThrowIfDisposed();
-      Utils.CheckReturnEnum(NativeRcl.rcl_wait_set_resize(
-      ref Handle,
-      (UIntPtr)subscriptionCount,
-      (UIntPtr)0,
-      (UIntPtr)0,
-      (UIntPtr)clientCount,
-      (UIntPtr)serviceCount,
-      (UIntPtr)0));
+      lock (mutex)
+      {
+        ThrowIfDisposed();
+        Utils.CheckReturnEnum(NativeRcl.rcl_wait_set_resize(
+        ref Handle,
+        (UIntPtr)subscriptionCount,
+        (UIntPtr)0,
+        (UIntPtr)0,
+        (UIntPtr)clientCount,
+        (UIntPtr)serviceCount,
+        (UIntPtr)0));
+      }
     }
 
     internal AddResult TryAddSubscription(ISubscriptionBase subscription, out ulong index)
     {
-      if (disposed)
+      lock (mutex)
       {
-        index = default(ulong);
-        return AddResult.DISPOSED;
-      }
-
-      UIntPtr native_index = default(UIntPtr);
-      int ret;
-      // Entity locks prevent Dispose from finalizing handles while they are being registered.
-      lock (subscription.Mutex)
-      {
-        if (subscription.IsDisposed)
+        if (disposed)
         {
           index = default(ulong);
           return AddResult.DISPOSED;
         }
 
-        rcl_subscription_t subscription_handle = subscription.Handle;
-        ret = NativeRcl.rcl_wait_set_add_subscription(
-          ref Handle,
-          ref subscription_handle,
-          ref native_index
-        );
-      }
+        UIntPtr native_index = default(UIntPtr);
+        int ret;
+        // Entity locks prevent Dispose from finalizing handles while they are being registered.
+        lock (subscription.Mutex)
+        {
+          if (subscription.IsDisposed)
+          {
+            index = default(ulong);
+            return AddResult.DISPOSED;
+          }
 
-      if ((RCLReturnEnum)ret == RCLReturnEnum.RCL_RET_WAIT_SET_FULL)
-      {
-        index = default(ulong);
-        return AddResult.FULL;
-      }
-      else
-      {
-        Utils.CheckReturnEnum(ret);
-        index = native_index.ToUInt64();
-        return AddResult.SUCCESS;
+          rcl_subscription_t subscription_handle = subscription.Handle;
+          ret = NativeRcl.rcl_wait_set_add_subscription(
+            ref Handle,
+            ref subscription_handle,
+            ref native_index
+          );
+        }
+
+        if ((RCLReturnEnum)ret == RCLReturnEnum.RCL_RET_WAIT_SET_FULL)
+        {
+          index = default(ulong);
+          return AddResult.FULL;
+        }
+        else
+        {
+          Utils.CheckReturnEnum(ret);
+          index = native_index.ToUInt64();
+          return AddResult.SUCCESS;
+        }
       }
     }
 
     internal AddResult TryAddClient(IClientBase client, out ulong index)
     {
-      if (disposed)
+      lock (mutex)
       {
-        index = default(ulong);
-        return AddResult.DISPOSED;
-      }
-
-      UIntPtr native_index = default(UIntPtr);
-      int ret;
-      // Entity locks prevent Dispose from finalizing handles while they are being registered.
-      lock (client.Mutex)
-      {
-        if (client.IsDisposed)
+        if (disposed)
         {
           index = default(ulong);
           return AddResult.DISPOSED;
         }
 
-        rcl_client_t client_handle = client.Handle;
-        ret = NativeRcl.rcl_wait_set_add_client(
-          ref Handle,
-          ref client_handle,
-          ref native_index
-        );
-      }
-      
-      if ((RCLReturnEnum)ret == RCLReturnEnum.RCL_RET_WAIT_SET_FULL)
-      {
-        index = default(ulong);
-        return AddResult.FULL;
-      }
-      else
-      {
-        Utils.CheckReturnEnum(ret);
-        index = native_index.ToUInt64();
-        return AddResult.SUCCESS;
+        UIntPtr native_index = default(UIntPtr);
+        int ret;
+        // Entity locks prevent Dispose from finalizing handles while they are being registered.
+        lock (client.Mutex)
+        {
+          if (client.IsDisposed)
+          {
+            index = default(ulong);
+            return AddResult.DISPOSED;
+          }
+
+          rcl_client_t client_handle = client.Handle;
+          ret = NativeRcl.rcl_wait_set_add_client(
+            ref Handle,
+            ref client_handle,
+            ref native_index
+          );
+        }
+
+        if ((RCLReturnEnum)ret == RCLReturnEnum.RCL_RET_WAIT_SET_FULL)
+        {
+          index = default(ulong);
+          return AddResult.FULL;
+        }
+        else
+        {
+          Utils.CheckReturnEnum(ret);
+          index = native_index.ToUInt64();
+          return AddResult.SUCCESS;
+        }
       }
     }
 
     internal AddResult TryAddService(IServiceBase service, out ulong index)
     {
-      if (disposed)
+      lock (mutex)
       {
-        index = default(ulong);
-        return AddResult.DISPOSED;
-      }
-
-      UIntPtr native_index = default(UIntPtr);
-      int ret;
-
-      // Entity locks prevent Dispose from finalizing handles while they are being registered.
-      lock (service.Mutex)
-      {
-        if (service.IsDisposed)
+        if (disposed)
         {
           index = default(ulong);
           return AddResult.DISPOSED;
         }
 
-        rcl_service_t service_handle = service.Handle;
-        ret = NativeRcl.rcl_wait_set_add_service(
-          ref Handle,
-          ref service_handle,
-          ref native_index
-        );
-      }
+        UIntPtr native_index = default(UIntPtr);
+        int ret;
 
+        // Entity locks prevent Dispose from finalizing handles while they are being registered.
+        lock (service.Mutex)
+        {
+          if (service.IsDisposed)
+          {
+            index = default(ulong);
+            return AddResult.DISPOSED;
+          }
 
-      if ((RCLReturnEnum)ret == RCLReturnEnum.RCL_RET_WAIT_SET_FULL)
-      {
-        index = default(ulong);
-        return AddResult.FULL;
-      }
-      else
-      {
-        Utils.CheckReturnEnum(ret);
-        index = native_index.ToUInt64();
-        return AddResult.SUCCESS;
+          rcl_service_t service_handle = service.Handle;
+          ret = NativeRcl.rcl_wait_set_add_service(
+            ref Handle,
+            ref service_handle,
+            ref native_index
+          );
+        }
+
+        if ((RCLReturnEnum)ret == RCLReturnEnum.RCL_RET_WAIT_SET_FULL)
+        {
+          index = default(ulong);
+          return AddResult.FULL;
+        }
+        else
+        {
+          Utils.CheckReturnEnum(ret);
+          index = native_index.ToUInt64();
+          return AddResult.SUCCESS;
+        }
       }
     }
 
@@ -241,16 +256,19 @@ namespace ROS2
 
     internal bool Wait(TimeSpan timeout)
     {
-      ThrowIfDisposed();
-      int ret = NativeRcl.rcl_wait(ref Handle, timeout.Ticks * 100);
-      if ((RCLReturnEnum)ret == RCLReturnEnum.RCL_RET_TIMEOUT)
+      lock (mutex)
       {
-        return false;
-      }
-      else
-      {
-        Utils.CheckReturnEnum(ret);
-        return true;
+        ThrowIfDisposed();
+        int ret = NativeRcl.rcl_wait(ref Handle, timeout.Ticks * 100);
+        if ((RCLReturnEnum)ret == RCLReturnEnum.RCL_RET_TIMEOUT)
+        {
+          return false;
+        }
+        else
+        {
+          Utils.CheckReturnEnum(ret);
+          return true;
+        }
       }
     }
 

--- a/src/ros2cs/ros2cs_core/WaitSet.cs
+++ b/src/ros2cs/ros2cs_core/WaitSet.cs
@@ -16,6 +16,7 @@
 // Modifications by Jianbin Liu:
 // - Made wait set lifetime disposable.
 // - Added disposed-state checks for spin and entity registration.
+// - Removed the unused wrapper Clear method; resizing is the active spin path.
 
 using System;
 
@@ -96,12 +97,6 @@ namespace ROS2
       {
         disposed = true;
       }
-    }
-
-    internal void Clear()
-    {
-      ThrowIfDisposed();
-      Utils.CheckReturnEnum(NativeRcl.rcl_wait_set_clear(ref Handle));
     }
 
     internal void Resize(ulong subscriptionCount, ulong clientCount, ulong serviceCount)

--- a/src/ros2cs/ros2cs_core/interfaces/IClient.cs
+++ b/src/ros2cs/ros2cs_core/interfaces/IClient.cs
@@ -18,7 +18,7 @@ using System.Threading.Tasks;
 
 namespace ROS2
 {
-  /// <summary> Non-generic base interface for all subscriptions </summary>
+  /// <summary> Non-generic base interface for all clients </summary>
   /// <seealso cref="INode.CreateClient"/>
   public interface IClientBase: IExtendedDisposable
   {
@@ -28,7 +28,7 @@ namespace ROS2
     /// <remarks>
     /// Marks the corresponding <see cref="Task"/> as finished if successful
     /// </remarks>
-    // TODO this should not be public - add an internal interface
+    // Internal spin entry point; kept on the public interface for compatibility.
     void TakeMessage();
 
     /// <summary>
@@ -51,13 +51,14 @@ namespace ROS2
     /// <returns>Whether the Task was removed successfully.</returns>
     bool Cancel(Task task);
 
+    // Internal wait-set handle; kept on the public interface for compatibility.
     rcl_client_t Handle {get;}
 
-    /// <summary> service mutex for internal use </summary>
+    /// <summary> client mutex for internal use </summary>
     object Mutex { get; }
   }
 
-  /// <summary> Generic base interface for all subscriptions </summary>
+  /// <summary> Generic base interface for all clients </summary>
   /// <typeparam name="I">Message Type to be send</typeparam>
   /// <typeparam name="O">Message Type to be received</typeparam>
   /// <seealso cref="INode.CreateClient"/>
@@ -73,7 +74,7 @@ namespace ROS2
     /// <summary>
     /// Check if the service to be called is available
     /// </summary>
-    /// <returns><see cref="true"/> if the service is avilable</returns>
+    /// <returns><see cref="true"/> if the service is available</returns>
     bool IsServiceAvailable();
 
     /// <summary>

--- a/src/ros2cs/ros2cs_core/interfaces/IClient.cs
+++ b/src/ros2cs/ros2cs_core/interfaces/IClient.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -82,6 +83,15 @@ namespace ROS2
     /// <param name="msg">Message to be send</param>
     /// <returns>Response of the Service</returns>
     O Call(I msg);
+
+    /// <summary>
+    /// Send a Request to a Service and wait up to the given timeout for a Response
+    /// </summary>
+    /// <remarks>The pending request is canceled when the timeout elapses</remarks>
+    /// <param name="msg">Message to be send</param>
+    /// <param name="timeout">Maximum time to wait for a response</param>
+    /// <returns>Response of the Service</returns>
+    O Call(I msg, TimeSpan timeout);
 
     /// <summary>
     /// Send a Request to a Service and wait for a Response asynchronously

--- a/src/ros2cs/ros2cs_core/interfaces/IClient.cs
+++ b/src/ros2cs/ros2cs_core/interfaces/IClient.cs
@@ -1,4 +1,8 @@
 // Copyright 2019-2021 Robotec.ai
+// Modifications Copyright (c) 2026 Jianbin Liu.
+//
+// Modifications by Jianbin Liu:
+// - Audited client interface contracts after lifecycle and timeout-path fixes.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/ros2cs/ros2cs_core/interfaces/INode.cs
+++ b/src/ros2cs/ros2cs_core/interfaces/INode.cs
@@ -34,7 +34,7 @@ namespace ROS2
     /// <description> Can only be called in an initialized Ros2cs state. </description>
     /// <param name="topic"> Topic for the client. Naming restrictions of ros2 apply and violation results in an exception </param>
     /// <param name="qos"> Quality of Client settings. Not passing this parameter will result in default settings </param>
-    /// <returns> Client for the topic, which can be used to client messages </returns>
+    /// <returns> Client for the topic, which can be used to send service requests </returns>
     Client<I, O> CreateClient<I, O>(string topic, QualityOfServiceProfile qos = null) where I : Message, new() where O : Message, new();
 
     /// <summary> Remove a client </summary>

--- a/src/ros2cs/ros2cs_core/interfaces/INode.cs
+++ b/src/ros2cs/ros2cs_core/interfaces/INode.cs
@@ -1,4 +1,5 @@
 // Copyright 2019-2021 Robotec.ai
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +12,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// Modifications by Jianbin Liu:
+// - Corrected Remove* documentation to match the implementation's disposal behavior.
 
 using System;
 using System.Collections.Generic;
@@ -34,7 +38,7 @@ namespace ROS2
     Client<I, O> CreateClient<I, O>(string topic, QualityOfServiceProfile qos = null) where I : Message, new() where O : Message, new();
 
     /// <summary> Remove a client </summary>
-    /// <remarks> Note that this does not call Dispose on Client </remarks>
+    /// <remarks> Removes the client from the node and calls Dispose on it. </remarks>
     /// <param name="client"> Client created with earlier CreateClient call </param>
     /// <returns> Whether removal actually took place. Safe to ignore </returns>
     bool RemoveClient(IClientBase client);
@@ -48,7 +52,7 @@ namespace ROS2
     Service<I, O> CreateService<I, O>(string topic, Func<I, O> callback, QualityOfServiceProfile qos = null) where I : Message, new() where O : Message, new();
 
     /// <summary> Remove a service </summary>
-    /// <remarks> Note that this does not call Dispose on Service </remarks>
+    /// <remarks> Removes the service from the node and calls Dispose on it. </remarks>
     /// <param name="service"> Service created with earlier CreateService call </param>
     /// <returns> Whether removal actually took place. Safe to ignore </returns>
     bool RemoveService(IServiceBase service);
@@ -69,14 +73,13 @@ namespace ROS2
     Subscription<T> CreateSubscription<T>(string topic, Action<T> callback, QualityOfServiceProfile qos = null) where T : Message, new();
 
     /// <summary> Remove a publisher </summary>
-    /// <remarks> Note that this does not call Dispose on Publisher </remarks>
+    /// <remarks> Removes the publisher from the node and calls Dispose on it. </remarks>
     /// <param name="publisher"> Publisher created with earlier CreatePublisher call </param>
     /// <returns> Whether removal actually took place. Safe to ignore </returns>
     bool RemovePublisher(IPublisherBase publisher);
 
     /// <summary> Remove a subscription </summary>
-    /// <remarks> Note that this does not call Dispose on Subscription. If the caller also does not own
-    /// the subscription, it can be garbage collected. You can also call Dispose after calling this </remarks>
+    /// <remarks> Removes the subscription from the node and calls Dispose on it. </remarks>
     /// <param name="subscription"> Subscription created with earlier CreateSubscription call </param>
     /// <returns> Whether removal actually took place. Safe to ignore </returns>
     bool RemoveSubscription(ISubscriptionBase subscription);

--- a/src/ros2cs/ros2cs_core/interfaces/IPublisher.cs
+++ b/src/ros2cs/ros2cs_core/interfaces/IPublisher.cs
@@ -1,4 +1,8 @@
 // Copyright 2019-2021 Robotec.ai
+// Modifications Copyright (c) 2026 Jianbin Liu.
+//
+// Modifications by Jianbin Liu:
+// - Audited publisher interface contracts after disposal and publish-lock fixes.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/ros2cs/ros2cs_core/interfaces/IPublisher.cs
+++ b/src/ros2cs/ros2cs_core/interfaces/IPublisher.cs
@@ -16,7 +16,7 @@ using System;
 
 namespace ROS2
 {
-  /// <summary> Non-generic base interface for all subscriptions </summary>
+  /// <summary> Non-generic base interface for all publishers </summary>
   /// <description> Use Ros2cs.CreatePublisher to construct.
   /// This interface is useful for managing publisher collections and disposal </description>
   public interface IPublisherBase: IExtendedDisposable
@@ -24,7 +24,7 @@ namespace ROS2
     string Topic {get;}
   }
 
-  /// <summary> Generic base interface for all subscriptions </summary>
+  /// <summary> Generic base interface for all publishers </summary>
   public interface IPublisher<T>: IPublisherBase
       where T: Message
   {

--- a/src/ros2cs/ros2cs_core/interfaces/IService.cs
+++ b/src/ros2cs/ros2cs_core/interfaces/IService.cs
@@ -1,4 +1,8 @@
 // Copyright 2019-2021 Robotec.ai
+// Modifications Copyright (c) 2026 Jianbin Liu.
+//
+// Modifications by Jianbin Liu:
+// - Audited service interface contracts after callback/error-path hardening.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/ros2cs/ros2cs_core/interfaces/IService.cs
+++ b/src/ros2cs/ros2cs_core/interfaces/IService.cs
@@ -16,7 +16,7 @@ using System;
 
 namespace ROS2
 {
-  /// <summary> Non-generic base interface for all subscriptions </summary>
+  /// <summary> Non-generic base interface for all services </summary>
   /// <seealso cref="INode.CreateService"/>
   public interface IServiceBase : IExtendedDisposable
   {
@@ -24,7 +24,7 @@ namespace ROS2
     /// Tries to get a request message from rcl/rmw layers
     /// </summary>
     /// <remarks>Invokes the callback if successful</remarks>
-    // TODO(adamdbrw) this should not be public - add an internal interface
+    // Internal spin entry point; kept on the public interface for compatibility.
     void TakeMessage();
 
     /// <summary>
@@ -32,7 +32,7 @@ namespace ROS2
     /// </summary>
     string Topic {get;}
 
-    // TODO(adamdbrw) this should not be public - add an internal interface
+    // Internal wait-set handle; kept on the public interface for compatibility.
     rcl_service_t Handle {get;}
 
     /// <summary> service mutex for internal use </summary>

--- a/src/ros2cs/ros2cs_core/interfaces/ISubscription.cs
+++ b/src/ros2cs/ros2cs_core/interfaces/ISubscription.cs
@@ -1,4 +1,8 @@
 // Copyright 2019-2021 Robotec.ai
+// Modifications Copyright (c) 2026 Jianbin Liu.
+//
+// Modifications by Jianbin Liu:
+// - Audited subscription interface contracts after take-message ownership fixes.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/ros2cs/ros2cs_core/interfaces/ISubscription.cs
+++ b/src/ros2cs/ros2cs_core/interfaces/ISubscription.cs
@@ -20,13 +20,13 @@ namespace ROS2
   /// <description> Use Ros2cs.CreateSubscription to construct </description>
   public interface ISubscriptionBase : IExtendedDisposable
   {
-    // TODO(adamdbrw) this should not be public - add an internal interface
+    // Internal spin entry point; kept on the public interface for compatibility.
     void TakeMessage();
 
     /// <summary> topic name which was used when calling Ros2cs.CreateSubscription </summary>
     string Topic {get;}
 
-    // TODO(adamdbrw) this should not be public - add an internal interface
+    // Internal wait-set handle; kept on the public interface for compatibility.
     rcl_subscription_t Handle {get;}
 
     /// <summary> subscription mutex for internal use </summary>

--- a/src/ros2cs/ros2cs_core/native/NativeRcl.cs
+++ b/src/ros2cs/ros2cs_core/native/NativeRcl.cs
@@ -16,6 +16,7 @@
 // Modifications by Jianbin Liu:
 // - Retained native library handles while rcl delegates are in use.
 // - Exposed rcl_init_options_fini for native lifecycle tests.
+// - Corrected bool and argv marshalling for rcl ABI compatibility.
 
 using System;
 using System.Runtime.InteropServices;
@@ -80,6 +81,7 @@ namespace ROS2
         typeof(ShutdownType));
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    [return: MarshalAs(UnmanagedType.I1)]
     internal delegate bool ContextIsValidType(ref rcl_context_t context);
     internal static ContextIsValidType
         rcl_context_is_valid =
@@ -89,7 +91,7 @@ namespace ROS2
         typeof(ContextIsValidType));
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate int InitType(int argc, [In, Out] string[] argv, ref rcl_init_options_t option, ref rcl_context_t context);
+    internal delegate int InitType(int argc, [In] string[] argv, ref rcl_init_options_t option, ref rcl_context_t context);
     internal static InitType
         rcl_init =
         (InitType)Marshal.GetDelegateForFunctionPointer(dllLoadUtils.GetProcAddress(
@@ -315,6 +317,7 @@ namespace ROS2
         typeof(SubscriptionFiniType));
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    [return: MarshalAs(UnmanagedType.I1)]
     internal delegate bool SubscriptionIsValidType(ref rcl_subscription_t subscription);
     internal static SubscriptionIsValidType
         rcl_subscription_is_valid =

--- a/src/ros2cs/ros2cs_core/native/NativeRcl.cs
+++ b/src/ros2cs/ros2cs_core/native/NativeRcl.cs
@@ -152,15 +152,7 @@ namespace ROS2
         typeof(NodeGetNamespaceType));
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate IntPtr ClientGetDefaultOptionsType();
-    internal static ClientGetDefaultOptionsType
-        rcl_client_get_default_options =
-        (ClientGetDefaultOptionsType)Marshal.GetDelegateForFunctionPointer(dllLoadUtils.GetProcAddress(
-        nativeRCL,
-        "rcl_client_get_default_options"),
-        typeof(ClientGetDefaultOptionsType));
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    // Keep the historical misspelled delegate type names: friend test assemblies bind field signatures to these types.
     internal delegate rcl_client_t GetZeroInitiazizedClientType();
     internal static GetZeroInitiazizedClientType
         rcl_get_zero_initialized_client =
@@ -215,15 +207,6 @@ namespace ROS2
         typeof(ServiceIsAvailableType));
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate IntPtr ServiceGetDefaultOptionsType();
-    internal static ServiceGetDefaultOptionsType
-        rcl_service_get_default_options =
-        (ServiceGetDefaultOptionsType)Marshal.GetDelegateForFunctionPointer(dllLoadUtils.GetProcAddress(
-        nativeRCL,
-        "rcl_service_get_default_options"),
-        typeof(ServiceGetDefaultOptionsType));
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     internal delegate rcl_service_t GetZeroInitiazizedServiceType();
     internal static GetZeroInitiazizedServiceType
         rcl_get_zero_initialized_service =
@@ -260,23 +243,13 @@ namespace ROS2
         typeof(TakeRequestType));
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate int SendResponceType( ref rcl_service_t service, ref rcl_rmw_request_id_t request_header, IntPtr responce_info);
-    ///internal delegate int SendResponceType( ref rcl_service_t service, ref rcl_rmw_request_id_t request_header, ref IntPtr responce_info);
+    internal delegate int SendResponceType(ref rcl_service_t service, ref rcl_rmw_request_id_t request_header, IntPtr response_info);
     internal static SendResponceType
         rcl_send_response =
         (SendResponceType)Marshal.GetDelegateForFunctionPointer(dllLoadUtils.GetProcAddress(
         nativeRCL,
         "rcl_send_response"),
         typeof(SendResponceType));
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate IntPtr PublisherGetDefaultOptionsType();
-    internal static PublisherGetDefaultOptionsType
-        rcl_publisher_get_default_options =
-        (PublisherGetDefaultOptionsType)Marshal.GetDelegateForFunctionPointer(dllLoadUtils.GetProcAddress(
-        nativeRCL,
-        "rcl_publisher_get_default_options"),
-        typeof(PublisherGetDefaultOptionsType));
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     internal delegate rcl_publisher_t GetZeroInitiazizedPublisherType();

--- a/src/ros2cs/ros2cs_core/native/NativeRcl.cs
+++ b/src/ros2cs/ros2cs_core/native/NativeRcl.cs
@@ -1,4 +1,5 @@
 // Copyright 2019-2021 Robotec.ai
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Modifications by Jianbin Liu:
+// - Retained native library handles while rcl delegates are in use.
+
 using System;
 using System.Runtime.InteropServices;
 
@@ -23,8 +27,11 @@ namespace ROS2
   internal static class NativeRcl
   {
     private static readonly DllLoadUtils dllLoadUtils = DllLoadUtilsFactory.GetDllLoadUtils();
-    private static readonly IntPtr nativeRCL = dllLoadUtils.LoadLibraryNoSuffix("rcl");
-    private static readonly IntPtr nativeRCUtils = dllLoadUtils.LoadLibraryNoSuffix("rcutils");
+    // Keep library handles alive for the lifetime of all delegates created from their symbols.
+    private static readonly NativeLibraryHandle nativeRCLHandle = NativeLibraryHandle.LoadLibraryNoSuffix(dllLoadUtils, "rcl");
+    private static readonly NativeLibraryHandle nativeRCUtilsHandle = NativeLibraryHandle.LoadLibraryNoSuffix(dllLoadUtils, "rcutils");
+    private static readonly IntPtr nativeRCL = nativeRCLHandle.Handle;
+    private static readonly IntPtr nativeRCUtils = nativeRCUtilsHandle.Handle;
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     internal delegate rcl_context_t GetZeroInitializedContextType();

--- a/src/ros2cs/ros2cs_core/native/NativeRcl.cs
+++ b/src/ros2cs/ros2cs_core/native/NativeRcl.cs
@@ -15,6 +15,7 @@
 
 // Modifications by Jianbin Liu:
 // - Retained native library handles while rcl delegates are in use.
+// - Exposed rcl_init_options_fini for native lifecycle tests.
 
 using System;
 using System.Runtime.InteropServices;
@@ -59,6 +60,15 @@ namespace ROS2
     nativeRCL,
     "rcl_init_options_init"),
     typeof(InitOptionsInitType));
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    internal delegate int InitOptionsFiniType(ref rcl_init_options_t init_options);
+    internal static InitOptionsFiniType
+    rcl_init_options_fini =
+    (InitOptionsFiniType)Marshal.GetDelegateForFunctionPointer(dllLoadUtils.GetProcAddress(
+    nativeRCL,
+    "rcl_init_options_fini"),
+    typeof(InitOptionsFiniType));
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     internal delegate int ShutdownType(ref rcl_context_t context);

--- a/src/ros2cs/ros2cs_core/native/NativeRclInterface.cs
+++ b/src/ros2cs/ros2cs_core/native/NativeRclInterface.cs
@@ -17,12 +17,21 @@
 // - Retained ros2cs native library handle while wrapper delegates are in use.
 // - Added calling convention metadata for rclcs init delegate.
 // - Corrected internal default-node-options delegate spelling.
+// - Shared the ros2cs native wrapper handle with rmw wrapper bindings.
 
 using System;
 using System.Runtime.InteropServices;
 
 namespace ROS2
 {
+  /// <summary>Shared owner for the ros2cs native wrapper library.</summary>
+  internal static class NativeRos2csLibrary
+  {
+    internal static readonly DllLoadUtils DllLoadUtils = DllLoadUtilsFactory.GetDllLoadUtils();
+    internal static readonly NativeLibraryHandle Handle = NativeLibraryHandle.LoadLibrary(DllLoadUtils, "ros2cs");
+    internal static readonly IntPtr Ptr = Handle.Handle;
+  }
+
   /// <summary>
   /// An internal class to manage all wrapped native calls to rcl and rcutils.
   /// These are wrapped usually for one of two reasons:
@@ -31,10 +40,8 @@ namespace ROS2
   /// </summary>
   internal static class NativeRclInterface
   {
-    private static readonly DllLoadUtils dllLoadUtils = DllLoadUtilsFactory.GetDllLoadUtils();
-    // Keep ros2cs native wrapper loaded while managed delegates point into it.
-    private static readonly NativeLibraryHandle nativeROS2CSHandle = NativeLibraryHandle.LoadLibrary(dllLoadUtils, "ros2cs");
-    private static readonly IntPtr nativeROS2CS = nativeROS2CSHandle.Handle;
+    private static readonly DllLoadUtils dllLoadUtils = NativeRos2csLibrary.DllLoadUtils;
+    private static readonly IntPtr nativeROS2CS = NativeRos2csLibrary.Ptr;
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     internal delegate int RCLCSInitType(ref rcl_context_t context, rcl_allocator_t allocator);

--- a/src/ros2cs/ros2cs_core/native/NativeRclInterface.cs
+++ b/src/ros2cs/ros2cs_core/native/NativeRclInterface.cs
@@ -18,6 +18,7 @@
 // - Added calling convention metadata for rclcs init delegate.
 // - Corrected internal default-node-options delegate spelling.
 // - Shared the ros2cs native wrapper handle with rmw wrapper bindings.
+// - Surfaced native option-dispose return codes where rcl fini can fail.
 
 using System;
 using System.Runtime.InteropServices;
@@ -80,7 +81,7 @@ namespace ROS2
         typeof(NodeCreateDefaultOptionsType));
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate void NodeDisposeOptionsType(IntPtr options);
+    internal delegate int NodeDisposeOptionsType(IntPtr options);
     internal static NodeDisposeOptionsType
         rclcs_node_dispose_options =
         (NodeDisposeOptionsType)Marshal.GetDelegateForFunctionPointer(dllLoadUtils.GetProcAddress(
@@ -98,7 +99,7 @@ namespace ROS2
         typeof(SubscriptionCreateOptionsType));
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate void SubscriptionDisposeOptionsType(IntPtr options);
+    internal delegate int SubscriptionDisposeOptionsType(IntPtr options);
     internal static SubscriptionDisposeOptionsType
         rclcs_subscription_dispose_options =
         (SubscriptionDisposeOptionsType)Marshal.GetDelegateForFunctionPointer(dllLoadUtils.GetProcAddress(

--- a/src/ros2cs/ros2cs_core/native/NativeRclInterface.cs
+++ b/src/ros2cs/ros2cs_core/native/NativeRclInterface.cs
@@ -16,6 +16,7 @@
 // Modifications by Jianbin Liu:
 // - Retained ros2cs native library handle while wrapper delegates are in use.
 // - Added calling convention metadata for rclcs init delegate.
+// - Corrected internal default-node-options delegate spelling.
 
 using System;
 using System.Runtime.InteropServices;
@@ -63,13 +64,13 @@ namespace ROS2
         typeof(DisposeErrorStringType));
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate IntPtr NodeCreateDefaltOptionsType();
-    internal static NodeCreateDefaltOptionsType
+    internal delegate IntPtr NodeCreateDefaultOptionsType();
+    internal static NodeCreateDefaultOptionsType
         rclcs_node_create_default_options =
-        (NodeCreateDefaltOptionsType)Marshal.GetDelegateForFunctionPointer(dllLoadUtils.GetProcAddress(
+        (NodeCreateDefaultOptionsType)Marshal.GetDelegateForFunctionPointer(dllLoadUtils.GetProcAddress(
         nativeROS2CS,
         "rclcs_node_create_default_options"),
-        typeof(NodeCreateDefaltOptionsType));
+        typeof(NodeCreateDefaultOptionsType));
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     internal delegate void NodeDisposeOptionsType(IntPtr options);

--- a/src/ros2cs/ros2cs_core/native/NativeRclInterface.cs
+++ b/src/ros2cs/ros2cs_core/native/NativeRclInterface.cs
@@ -1,4 +1,5 @@
 // Copyright 2019-2021 Robotec.ai
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// Modifications by Jianbin Liu:
+// - Retained ros2cs native library handle while wrapper delegates are in use.
+// - Added calling convention metadata for rclcs init delegate.
 
 using System;
 using System.Runtime.InteropServices;
@@ -26,8 +31,11 @@ namespace ROS2
   internal static class NativeRclInterface
   {
     private static readonly DllLoadUtils dllLoadUtils = DllLoadUtilsFactory.GetDllLoadUtils();
-    private static readonly IntPtr nativeROS2CS = dllLoadUtils.LoadLibrary("ros2cs");
+    // Keep ros2cs native wrapper loaded while managed delegates point into it.
+    private static readonly NativeLibraryHandle nativeROS2CSHandle = NativeLibraryHandle.LoadLibrary(dllLoadUtils, "ros2cs");
+    private static readonly IntPtr nativeROS2CS = nativeROS2CSHandle.Handle;
 
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     internal delegate int RCLCSInitType(ref rcl_context_t context, rcl_allocator_t allocator);
     internal static RCLCSInitType
         rclcs_init =

--- a/src/ros2cs/ros2cs_core/native/NativeRmwInterface.cs
+++ b/src/ros2cs/ros2cs_core/native/NativeRmwInterface.cs
@@ -16,6 +16,7 @@
 // Modifications by Jianbin Liu:
 // - Retained ros2cs native library handle while rmw delegates are in use.
 // - Shared the ros2cs native wrapper handle with rcl wrapper bindings.
+// - Normalized delegate binding indentation.
 
 using System;
 using System.Runtime.InteropServices;
@@ -66,22 +67,22 @@ namespace ROS2
       "rmw_native_interface_set_history"),
       typeof(RMWNativeSetHistoryIdentifierType));
 
-      [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-      internal delegate void RMWNativeSetReliabilityIdentifierType(IntPtr profile, int mode);
-      internal static RMWNativeSetReliabilityIdentifierType
-        rmw_native_interface_set_reliability =
-        (RMWNativeSetReliabilityIdentifierType)Marshal.GetDelegateForFunctionPointer(dllLoadUtils.GetProcAddress(
-        nativeRMW,
-        "rmw_native_interface_set_reliability"),
-        typeof(RMWNativeSetReliabilityIdentifierType));
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    internal delegate void RMWNativeSetReliabilityIdentifierType(IntPtr profile, int mode);
+    internal static RMWNativeSetReliabilityIdentifierType
+      rmw_native_interface_set_reliability =
+      (RMWNativeSetReliabilityIdentifierType)Marshal.GetDelegateForFunctionPointer(dllLoadUtils.GetProcAddress(
+      nativeRMW,
+      "rmw_native_interface_set_reliability"),
+      typeof(RMWNativeSetReliabilityIdentifierType));
 
-      [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-      internal delegate void RMWNativeSetDurabilityIdentifierType(IntPtr profile, int mode);
-      internal static RMWNativeSetDurabilityIdentifierType
-        rmw_native_interface_set_durability =
-        (RMWNativeSetDurabilityIdentifierType)Marshal.GetDelegateForFunctionPointer(dllLoadUtils.GetProcAddress(
-        nativeRMW,
-        "rmw_native_interface_set_durability"),
-        typeof(RMWNativeSetDurabilityIdentifierType));
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    internal delegate void RMWNativeSetDurabilityIdentifierType(IntPtr profile, int mode);
+    internal static RMWNativeSetDurabilityIdentifierType
+      rmw_native_interface_set_durability =
+      (RMWNativeSetDurabilityIdentifierType)Marshal.GetDelegateForFunctionPointer(dllLoadUtils.GetProcAddress(
+      nativeRMW,
+      "rmw_native_interface_set_durability"),
+      typeof(RMWNativeSetDurabilityIdentifierType));
   }
 }

--- a/src/ros2cs/ros2cs_core/native/NativeRmwInterface.cs
+++ b/src/ros2cs/ros2cs_core/native/NativeRmwInterface.cs
@@ -1,4 +1,5 @@
 // Copyright 2019-2021 Robotec.ai
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Modifications by Jianbin Liu:
+// - Retained ros2cs native library handle while rmw delegates are in use.
+
 using System;
 using System.Runtime.InteropServices;
 
@@ -23,7 +27,9 @@ namespace ROS2
   internal static class NativeRmwInterface
   {
     private static readonly DllLoadUtils dllLoadUtils = DllLoadUtilsFactory.GetDllLoadUtils();
-    private static readonly IntPtr nativeRMW = dllLoadUtils.LoadLibrary("ros2cs");
+    // Keep ros2cs native wrapper loaded while managed rmw delegates point into it.
+    private static readonly NativeLibraryHandle nativeRMWHandle = NativeLibraryHandle.LoadLibrary(dllLoadUtils, "ros2cs");
+    private static readonly IntPtr nativeRMW = nativeRMWHandle.Handle;
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     internal delegate IntPtr RMWImplementationIdentifier();

--- a/src/ros2cs/ros2cs_core/native/NativeRmwInterface.cs
+++ b/src/ros2cs/ros2cs_core/native/NativeRmwInterface.cs
@@ -15,6 +15,7 @@
 
 // Modifications by Jianbin Liu:
 // - Retained ros2cs native library handle while rmw delegates are in use.
+// - Shared the ros2cs native wrapper handle with rcl wrapper bindings.
 
 using System;
 using System.Runtime.InteropServices;
@@ -26,10 +27,8 @@ namespace ROS2
   /// </summary>
   internal static class NativeRmwInterface
   {
-    private static readonly DllLoadUtils dllLoadUtils = DllLoadUtilsFactory.GetDllLoadUtils();
-    // Keep ros2cs native wrapper loaded while managed rmw delegates point into it.
-    private static readonly NativeLibraryHandle nativeRMWHandle = NativeLibraryHandle.LoadLibrary(dllLoadUtils, "ros2cs");
-    private static readonly IntPtr nativeRMW = nativeRMWHandle.Handle;
+    private static readonly DllLoadUtils dllLoadUtils = NativeRos2csLibrary.DllLoadUtils;
+    private static readonly IntPtr nativeRMW = NativeRos2csLibrary.Ptr;
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     internal delegate IntPtr RMWImplementationIdentifier();

--- a/src/ros2cs/ros2cs_core/native/NativeTypes.cs
+++ b/src/ros2cs/ros2cs_core/native/NativeTypes.cs
@@ -1,4 +1,5 @@
 // Copyright 2019-2021 Robotec.ai
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +12,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// Modifications by Jianbin Liu:
+// - Added explicit sequential layout annotations for native interop structs.
 
 using System;
 using System.Runtime.InteropServices;
@@ -28,6 +32,8 @@ namespace ROS2
 
   #pragma warning disable 0169
 
+  /// <summary>Managed mirror of rcl_allocator_t with explicit native field order.</summary>
+  [StructLayout(LayoutKind.Sequential)]
   public struct rcl_allocator_t
   {
     public IntPtr allocate;
@@ -37,11 +43,15 @@ namespace ROS2
     public IntPtr state;
   }
 
+  /// <summary>Managed mirror of rcl_arguments_t with explicit native field order.</summary>
+  [StructLayout(LayoutKind.Sequential)]
   public struct rcl_arguments_t
   {
     private IntPtr impl;
   }
 
+  /// <summary>Managed mirror of rcl_context_t with explicit native field order.</summary>
+  [StructLayout(LayoutKind.Sequential)]
   public struct rcl_context_t
 {
     private IntPtr global_arguments;
@@ -49,42 +59,57 @@ namespace ROS2
     private IntPtr instance_id_storage;
   }
 
+  /// <summary>Managed mirror of rcl_error_string_t with explicit native field order.</summary>
+  [StructLayout(LayoutKind.Sequential)]
   public struct rcl_error_string_t
   {
     internal IntPtr str;
   }
 
+  /// <summary>Managed mirror of rcl_init_options_t with explicit native field order.</summary>
+  [StructLayout(LayoutKind.Sequential)]
   public struct rcl_init_options_t
   {
     private IntPtr impl;
   }
 
+  /// <summary>Managed mirror of rcl_node_t with explicit native field order.</summary>
+  [StructLayout(LayoutKind.Sequential)]
   public struct rcl_node_t
   {
     private IntPtr context;
     private IntPtr rcl_node_impl_t;
   }
 
+  /// <summary>Managed mirror of rcl_publisher_t with explicit native field order.</summary>
+  [StructLayout(LayoutKind.Sequential)]
   public struct rcl_publisher_t
   {
     private IntPtr impl;
   }
 
+  /// <summary>Managed mirror of rcl_subscription_t with explicit native field order.</summary>
+  [StructLayout(LayoutKind.Sequential)]
   public struct rcl_subscription_t
   {
     private IntPtr impl;
   }
 
+  /// <summary>Managed mirror of rcl_client_t with explicit native field order.</summary>
+  [StructLayout(LayoutKind.Sequential)]
   public struct rcl_client_t
   {
     private IntPtr impl;
   }
 
+  /// <summary>Managed mirror of rcl_service_t with explicit native field order.</summary>
+  [StructLayout(LayoutKind.Sequential)]
   public struct rcl_service_t
   {
     private IntPtr impl;
   }
 
+  /// <summary>Managed mirror of rcl_rmw_request_id_t with explicit native field order.</summary>
   [StructLayout(LayoutKind.Sequential)]
   public struct rcl_rmw_request_id_t
   {
@@ -96,6 +121,8 @@ namespace ROS2
     public long sequence_number;
   };
 
+  /// <summary>Managed mirror of rcl_wait_set_t with explicit native field order.</summary>
+  [StructLayout(LayoutKind.Sequential)]
   public struct rcl_wait_set_t
   {
     private IntPtr subscriptions;
@@ -113,6 +140,8 @@ namespace ROS2
     private IntPtr impl;
   }
 
+  /// <summary>Managed mirror of rcl_clock_t with explicit native field order.</summary>
+  [StructLayout(LayoutKind.Sequential)]
   public struct rcl_clock_t
   {
     private int type;

--- a/src/ros2cs/ros2cs_core/native/NativeTypes.cs
+++ b/src/ros2cs/ros2cs_core/native/NativeTypes.cs
@@ -15,6 +15,7 @@
 
 // Modifications by Jianbin Liu:
 // - Added explicit sequential layout annotations for native interop structs.
+// - Fixed rcl_context_t instance id storage to stay 8 bytes on 32-bit runtimes.
 
 using System;
 using System.Runtime.InteropServices;
@@ -56,7 +57,8 @@ namespace ROS2
 {
     private IntPtr global_arguments;
     private IntPtr impl;
-    private IntPtr instance_id_storage;
+    // Native rcl stores this as fixed 8-byte instance id storage, not a pointer.
+    private ulong instance_id_storage;
   }
 
   /// <summary>Managed mirror of rcl_error_string_t with explicit native field order.</summary>

--- a/src/ros2cs/ros2cs_core/native/RCLRet.cs
+++ b/src/ros2cs/ros2cs_core/native/RCLRet.cs
@@ -15,6 +15,7 @@
 
 // Modifications by Jianbin Liu:
 // - Added corrected return-code aliases for take-failed values.
+// - Marked legacy misspelled aliases obsolete while preserving compatibility.
 
 namespace ROS2
 {
@@ -54,6 +55,7 @@ namespace ROS2
     RCL_RET_SERVICE_INVALID = 600,
     // Correct spelling retained beside the legacy misspelled alias for compatibility.
     RCL_RET_SERVICE_TAKE_FAILED = 601,
+    [System.Obsolete("Use RCL_RET_SERVICE_TAKE_FAILED.")]
     RCL_RET_SERIVCE_TAKE_FAILD = 601,
     // rcl guard condition specific ret codes in 7XX
     // rcl timer specific ret codes in 8XX
@@ -66,6 +68,8 @@ namespace ROS2
 
     // rcl params, logs and events
     RCL_RET_INVALID_REMAP_RULE = 1001,
+    RCL_RET_WRONG_LEXEME = 1002,
+    [System.Obsolete("Use RCL_RET_WRONG_LEXEME.")]
     RCL_RET_WRONG_LEXME = 1002,
     RCL_RET_INVALID_ROS_ARGS = 1003,
     RCL_RET_INVALID_PARAM_RULE = 1010,
@@ -74,6 +78,7 @@ namespace ROS2
     RCL_RET_INVALID_EVENT_ID = 2000,
     // Correct spelling retained beside the legacy misspelled alias for compatibility.
     RCL_RET_EVENT_TAKE_FAILED = 2001,
+    [System.Obsolete("Use RCL_RET_EVENT_TAKE_FAILED.")]
     RCL_RET_EVENT_TAKE_FAILER = 2001
 	}
 }

--- a/src/ros2cs/ros2cs_core/native/RCLRet.cs
+++ b/src/ros2cs/ros2cs_core/native/RCLRet.cs
@@ -1,4 +1,5 @@
 // Copyright 2019-2021 Robotec.ai
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +12,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// Modifications by Jianbin Liu:
+// - Added corrected return-code aliases for take-failed values.
 
 namespace ROS2
 {
@@ -48,6 +52,8 @@ namespace ROS2
     RCL_RET_CLIENT_TAKE_FAILED = 501,
     // rcl service server specific ret codes in 6XX
     RCL_RET_SERVICE_INVALID = 600,
+    // Correct spelling retained beside the legacy misspelled alias for compatibility.
+    RCL_RET_SERVICE_TAKE_FAILED = 601,
     RCL_RET_SERIVCE_TAKE_FAILD = 601,
     // rcl guard condition specific ret codes in 7XX
     // rcl timer specific ret codes in 8XX
@@ -66,6 +72,8 @@ namespace ROS2
     RCL_RET_INVALID_LOG_LEVEL_RULE = 1020,
 
     RCL_RET_INVALID_EVENT_ID = 2000,
+    // Correct spelling retained beside the legacy misspelled alias for compatibility.
+    RCL_RET_EVENT_TAKE_FAILED = 2001,
     RCL_RET_EVENT_TAKE_FAILER = 2001
 	}
 }

--- a/src/ros2cs/ros2cs_core/native/rcl_native_interface.c
+++ b/src/ros2cs/ros2cs_core/native/rcl_native_interface.c
@@ -16,6 +16,8 @@
 // Modifications by Jianbin Liu:
 // - Added allocation failure and null dispose guards for clock wrappers.
 // - Finalizes rcl clock before freeing the wrapper allocation.
+// - Added allocation and null-argument guards for rcl option wrapper helpers.
+// - Finalizes rcl init options when rcl_init fails.
 
 #include <rcl/error_handling.h>
 #include <rcl/node.h>
@@ -25,6 +27,7 @@
 #include <rcutils/strdup.h>
 #include <rcutils/types.h>
 #include <rmw/qos_profiles.h>
+#include <stdlib.h>
 
 ROSIDL_GENERATOR_C_EXPORT
 int rclcs_init(rcl_context_t *context, rcl_allocator_t allocator)
@@ -39,6 +42,7 @@ int rclcs_init(rcl_context_t *context, rcl_allocator_t allocator)
   ret = rcl_init(0, NULL, &init_options, context);
   if (ret != RCL_RET_OK)
   {
+    rcl_init_options_fini(&init_options);
     return (int)ret;
   }
 
@@ -50,6 +54,10 @@ ROSIDL_GENERATOR_C_EXPORT
 rcl_node_options_t * rclcs_node_create_default_options()
 {
   rcl_node_options_t  * default_node_options_handle = (rcl_node_options_t *)malloc(sizeof(rcl_node_options_t));
+  if (default_node_options_handle == NULL)
+  {
+    return NULL;
+  }
   *default_node_options_handle = rcl_node_get_default_options();
   return default_node_options_handle;
 }
@@ -64,6 +72,15 @@ ROSIDL_GENERATOR_C_EXPORT
 rcl_subscription_options_t *rclcs_subscription_create_options(rmw_qos_profile_t * qos)
 {
   rcl_subscription_options_t  * default_subscription_options_handle = (rcl_subscription_options_t *)malloc(sizeof(rcl_subscription_options_t));
+  if (default_subscription_options_handle == NULL)
+  {
+    return NULL;
+  }
+  if (qos == NULL)
+  {
+    free(default_subscription_options_handle);
+    return NULL;
+  }
   *default_subscription_options_handle = rcl_subscription_get_default_options();
   default_subscription_options_handle->qos = *qos;
   return default_subscription_options_handle;
@@ -79,6 +96,15 @@ ROSIDL_GENERATOR_C_EXPORT
 rcl_publisher_options_t *rclcs_publisher_create_options(rmw_qos_profile_t * qos)
 {
   rcl_publisher_options_t *default_publisher_options_handle = (rcl_publisher_options_t *)malloc(sizeof(rcl_publisher_options_t));
+  if (default_publisher_options_handle == NULL)
+  {
+    return NULL;
+  }
+  if (qos == NULL)
+  {
+    free(default_publisher_options_handle);
+    return NULL;
+  }
   *default_publisher_options_handle = rcl_publisher_get_default_options();
   default_publisher_options_handle->qos = *qos;
   return default_publisher_options_handle;
@@ -94,6 +120,15 @@ ROSIDL_GENERATOR_C_EXPORT
 rcl_client_options_t *rclcs_client_create_options(rmw_qos_profile_t * qos)
 {
   rcl_client_options_t *default_client_options_handle = (rcl_client_options_t *)malloc(sizeof(rcl_client_options_t));
+  if (default_client_options_handle == NULL)
+  {
+    return NULL;
+  }
+  if (qos == NULL)
+  {
+    free(default_client_options_handle);
+    return NULL;
+  }
   *default_client_options_handle = rcl_client_get_default_options();
   default_client_options_handle->qos = *qos;
   return default_client_options_handle;
@@ -109,6 +144,15 @@ ROSIDL_GENERATOR_C_EXPORT
 rcl_service_options_t *rclcs_service_create_options(rmw_qos_profile_t * qos)
 {
   rcl_service_options_t *default_service_options_handle = (rcl_service_options_t *)malloc(sizeof(rcl_service_options_t));
+  if (default_service_options_handle == NULL)
+  {
+    return NULL;
+  }
+  if (qos == NULL)
+  {
+    free(default_service_options_handle);
+    return NULL;
+  }
   *default_service_options_handle = rcl_service_get_default_options();
   default_service_options_handle->qos = *qos;
   return default_service_options_handle;

--- a/src/ros2cs/ros2cs_core/native/rcl_native_interface.c
+++ b/src/ros2cs/ros2cs_core/native/rcl_native_interface.c
@@ -18,6 +18,7 @@
 // - Finalizes rcl clock before freeing the wrapper allocation.
 // - Added allocation and null-argument guards for rcl option wrapper helpers.
 // - Finalizes rcl init options when rcl_init fails.
+// - Finalizes node options before freeing their wrapper allocation.
 
 #include <rcl/error_handling.h>
 #include <rcl/node.h>
@@ -65,6 +66,12 @@ rcl_node_options_t * rclcs_node_create_default_options()
 ROSIDL_GENERATOR_C_EXPORT
 void rclcs_node_dispose_options(rcl_node_options_t * node_options_handle)
 {
+  if (node_options_handle == NULL)
+  {
+    return;
+  }
+  rcl_ret_t ret = rcl_node_options_fini(node_options_handle);
+  (void)ret;
   free(node_options_handle);
 }
 

--- a/src/ros2cs/ros2cs_core/native/rcl_native_interface.c
+++ b/src/ros2cs/ros2cs_core/native/rcl_native_interface.c
@@ -19,6 +19,7 @@
 // - Added allocation and null-argument guards for rcl option wrapper helpers.
 // - Finalizes rcl init options when rcl_init fails.
 // - Finalizes node options before freeing their wrapper allocation.
+// - Surfaced option finalization return codes and guarded null option disposals.
 
 #include <rcl/error_handling.h>
 #include <rcl/node.h>
@@ -64,15 +65,15 @@ rcl_node_options_t * rclcs_node_create_default_options()
 }
 
 ROSIDL_GENERATOR_C_EXPORT
-void rclcs_node_dispose_options(rcl_node_options_t * node_options_handle)
+int rclcs_node_dispose_options(rcl_node_options_t * node_options_handle)
 {
   if (node_options_handle == NULL)
   {
-    return;
+    return RCL_RET_OK;
   }
   rcl_ret_t ret = rcl_node_options_fini(node_options_handle);
-  (void)ret;
   free(node_options_handle);
+  return (int)ret;
 }
 
 ROSIDL_GENERATOR_C_EXPORT
@@ -94,9 +95,15 @@ rcl_subscription_options_t *rclcs_subscription_create_options(rmw_qos_profile_t 
 }
 
 ROSIDL_GENERATOR_C_EXPORT
-void rclcs_subscription_dispose_options(rcl_subscription_options_t *subscription_options_handle)
+int rclcs_subscription_dispose_options(rcl_subscription_options_t *subscription_options_handle)
 {
+  if (subscription_options_handle == NULL)
+  {
+    return RCL_RET_OK;
+  }
+  rcl_ret_t ret = rcl_subscription_options_fini(subscription_options_handle);
   free(subscription_options_handle);
+  return (int)ret;
 }
 
 ROSIDL_GENERATOR_C_EXPORT
@@ -120,6 +127,11 @@ rcl_publisher_options_t *rclcs_publisher_create_options(rmw_qos_profile_t * qos)
 ROSIDL_GENERATOR_C_EXPORT
 void rclcs_publisher_dispose_options(rcl_publisher_options_t * publisher_options_handle)
 {
+  // Jazzy exposes no rcl_publisher_options_fini; defaults are plain values today.
+  if (publisher_options_handle == NULL)
+  {
+    return;
+  }
   free(publisher_options_handle);
 }
 
@@ -144,6 +156,11 @@ rcl_client_options_t *rclcs_client_create_options(rmw_qos_profile_t * qos)
 ROSIDL_GENERATOR_C_EXPORT
 void rclcs_client_dispose_options(rcl_client_options_t * client_options_handle)
 {
+  // Jazzy exposes no rcl_client_options_fini; defaults are plain values today.
+  if (client_options_handle == NULL)
+  {
+    return;
+  }
   free(client_options_handle);
 }
 
@@ -168,6 +185,11 @@ rcl_service_options_t *rclcs_service_create_options(rmw_qos_profile_t * qos)
 ROSIDL_GENERATOR_C_EXPORT
 void rclcs_service_dispose_options(rcl_service_options_t * service_options_handle)
 {
+  // Jazzy exposes no rcl_service_options_fini; defaults are plain values today.
+  if (service_options_handle == NULL)
+  {
+    return;
+  }
   free(service_options_handle);
 }
 

--- a/src/ros2cs/ros2cs_core/native/rcl_native_interface.c
+++ b/src/ros2cs/ros2cs_core/native/rcl_native_interface.c
@@ -1,4 +1,5 @@
 // Copyright 2019-2021 Robotec.ai
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// Modifications by Jianbin Liu:
+// - Added allocation failure and null dispose guards for clock wrappers.
+// - Finalizes rcl clock before freeing the wrapper allocation.
 
 #include <rcl/error_handling.h>
 #include <rcl/node.h>
@@ -133,10 +138,16 @@ ROSIDL_GENERATOR_C_EXPORT
 rcl_clock_t * rclcs_ros_clock_create(rcl_allocator_t * allocator_handle)
 {
   rcl_clock_t  * clock_handle = (rcl_clock_t *)malloc(sizeof(rcl_clock_t));
+  // Return NULL on allocation failure so managed code can throw a clear creation error.
+  if (clock_handle == NULL)
+  {
+    return NULL;
+  }
   int32_t ret = rcl_ros_clock_init(clock_handle, allocator_handle);
   if (ret != RCL_RET_OK)
   {
     free(clock_handle);
+    return NULL;
   }
   return clock_handle;
 }
@@ -144,5 +155,12 @@ rcl_clock_t * rclcs_ros_clock_create(rcl_allocator_t * allocator_handle)
 ROSIDL_GENERATOR_C_EXPORT
 void rclcs_ros_clock_dispose(rcl_clock_t * clock_handle)
 {
+  // Dispose can be called from finalizers or failed construction paths; NULL is a no-op.
+  if (clock_handle == NULL)
+  {
+    return;
+  }
+  // Finalize the rcl clock before freeing the wrapper allocation.
+  rcl_clock_fini(clock_handle);
   free(clock_handle);
 }

--- a/src/ros2cs/ros2cs_core/native/rmw_native_interface.c
+++ b/src/ros2cs/ros2cs_core/native/rmw_native_interface.c
@@ -1,4 +1,5 @@
 // Copyright 2019-2021 Robotec.ai
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,10 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Modifications by Jianbin Liu:
+// - Added allocation and null-argument guards for QoS profile helpers.
+
 #include <rmw/qos_profiles.h>
 #include <rmw/types.h>
 #include <rmw/rmw.h>
 #include <rcl/rcl.h>
+#include <stdlib.h>
 
 ROSIDL_GENERATOR_C_EXPORT
 rmw_qos_profile_t * rmw_native_interface_create_qos_profile(int profile)
@@ -31,6 +36,10 @@ rmw_qos_profile_t * rmw_native_interface_create_qos_profile(int profile)
   };
 
   rmw_qos_profile_t * preset_profile = (rmw_qos_profile_t *)malloc(sizeof(rmw_qos_profile_t));
+  if (preset_profile == NULL)
+  {
+    return NULL;
+  }
 
   switch (profile)
   {
@@ -61,6 +70,10 @@ void rmw_native_interface_delete_qos_profile(rmw_qos_profile_t * profile)
 ROSIDL_GENERATOR_C_EXPORT
 void rmw_native_interface_set_history(rmw_qos_profile_t * profile, int history_mode, int history_depth)
 {
+  if (profile == NULL)
+  {
+    return;
+  }
   profile->history = history_mode;
   profile->depth = (size_t)history_depth;
 }
@@ -68,11 +81,19 @@ void rmw_native_interface_set_history(rmw_qos_profile_t * profile, int history_m
 ROSIDL_GENERATOR_C_EXPORT
 void rmw_native_interface_set_reliability(rmw_qos_profile_t * profile, int reliability_mode)
 {
+  if (profile == NULL)
+  {
+    return;
+  }
   profile->reliability = reliability_mode;
 }
 
 ROSIDL_GENERATOR_C_EXPORT
 void rmw_native_interface_set_durability(rmw_qos_profile_t * profile, int durability_mode)
 {
+  if (profile == NULL)
+  {
+    return;
+  }
   profile->durability = durability_mode;
 }

--- a/src/ros2cs/ros2cs_core/utils/Utils.cs
+++ b/src/ros2cs/ros2cs_core/utils/Utils.cs
@@ -15,6 +15,7 @@
 
 // Modifications by Jianbin Liu:
 // - Split rcl exception throwing so callers can inspect/filter native error messages.
+// - Ensured native error strings are released even if managed marshaling fails.
 
 using System;
 using System.Runtime.InteropServices;
@@ -57,9 +58,17 @@ namespace ROS2
     internal static string GetRclErrorString()
     {
       IntPtr errorStringPtr = NativeRclInterface.rclcs_get_error_string();
-      string errorString = PtrToString(errorStringPtr);
-      NativeRclInterface.rclcs_dispose_error_string(errorStringPtr);
-      return errorString;
+      try
+      {
+        return PtrToString(errorStringPtr);
+      }
+      finally
+      {
+        if (errorStringPtr != IntPtr.Zero)
+        {
+          NativeRclInterface.rclcs_dispose_error_string(errorStringPtr);
+        }
+      }
     }
 
     /// <summary> Get and clean last rcl error </summary>

--- a/src/ros2cs/ros2cs_core/utils/Utils.cs
+++ b/src/ros2cs/ros2cs_core/utils/Utils.cs
@@ -18,6 +18,7 @@
 // - Ensured native error strings are released even if managed marshaling fails.
 
 using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
 namespace ROS2
@@ -49,8 +50,32 @@ namespace ROS2
         case RCLReturnEnum.RCL_RET_WAIT_SET_EMPTY:
           throw new WaitSetEmptyException(errorMessage);
         default:
-          throw new RuntimeError(errorMessage);
+          throw new RuntimeError(errorMessage, ret);
       }
+    }
+
+    /// <summary>Add an exception to a lazily-created collection.</summary>
+    internal static void AddException(ref List<Exception> exceptions, Exception exception)
+    {
+      if (exceptions == null)
+      {
+        exceptions = new List<Exception>();
+      }
+      exceptions.Add(exception);
+    }
+
+    /// <summary>Throw one collected exception directly or aggregate multiple failures.</summary>
+    internal static void ThrowCollectedExceptions(List<Exception> exceptions)
+    {
+      if (exceptions == null || exceptions.Count == 0)
+      {
+        return;
+      }
+      if (exceptions.Count == 1)
+      {
+        throw exceptions[0];
+      }
+      throw new AggregateException(exceptions);
     }
 
     /// <summary> Get last rcl error </summary>

--- a/src/ros2cs/ros2cs_core/utils/Utils.cs
+++ b/src/ros2cs/ros2cs_core/utils/Utils.cs
@@ -1,4 +1,5 @@
 // Copyright 2019-2021 Robotec.ai
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Modifications by Jianbin Liu:
+// - Split rcl exception throwing so callers can inspect/filter native error messages.
+
 using System;
 using System.Runtime.InteropServices;
 
@@ -23,12 +27,20 @@ namespace ROS2
     /// <summary> Helper checker and converter of rcl return values to exceptions </summary>
     internal static void CheckReturnEnum(int ret)
     {
-      string errorMessage = Utils.PopRclErrorString();
+      if ((RCLReturnEnum)ret == RCLReturnEnum.RCL_RET_OK)
+      {
+        return;
+      }
 
+      string errorMessage = Utils.PopRclErrorString();
+      ThrowRclException(ret, errorMessage);
+    }
+
+    /// <summary>Throw a typed managed exception for an rcl return code and supplied error text.</summary>
+    internal static void ThrowRclException(int ret, string errorMessage)
+    {
       switch ((RCLReturnEnum)ret)
       {
-        case RCLReturnEnum.RCL_RET_OK:
-          break;
         case RCLReturnEnum.RCL_RET_NODE_INVALID_NAME:
           throw new InvalidNodeNameException(errorMessage);
         case RCLReturnEnum.RCL_RET_NODE_INVALID_NAMESPACE:

--- a/src/ros2cs/ros2cs_examples/CMakeLists.txt
+++ b/src/ros2cs/ros2cs_examples/CMakeLists.txt
@@ -28,7 +28,6 @@ find_package(sensor_msgs REQUIRED)
 find_package(example_interfaces REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(dotnet_cmake_module REQUIRED)
-find_package(rosidl_generator_cs REQUIRED)
 
 # Build examples on .NET 8 while core/common remain netstandard2.0.
 set(CSHARP_TARGET_FRAMEWORK "net8.0")
@@ -47,36 +46,42 @@ set(_assemblies_dep_dlls
 
 add_dotnet_executable(ros2cs_talker
   ROS2Talker.cs
+  ROS2ExampleRuntime.cs
   INCLUDE_DLLS
   ${_assemblies_dep_dlls}
 )
 
 add_dotnet_executable(ros2cs_listener
   ROS2Listener.cs
+  ROS2ExampleRuntime.cs
   INCLUDE_DLLS
   ${_assemblies_dep_dlls}
 )
 
 add_dotnet_executable(ros2cs_performance_talker
   ROS2PerformanceTalker.cs
+  ROS2ExampleRuntime.cs
   INCLUDE_DLLS
   ${_assemblies_dep_dlls}
 )
 
 add_dotnet_executable(ros2cs_performance_listener
   ROS2PerformanceListener.cs
+  ROS2ExampleRuntime.cs
   INCLUDE_DLLS
   ${_assemblies_dep_dlls}
 )
 
 add_dotnet_executable(ros2cs_client
   ROS2Client.cs
+  ROS2ExampleRuntime.cs
   INCLUDE_DLLS
   ${_assemblies_dep_dlls}
 )
 
 add_dotnet_executable(ros2cs_service
   ROS2Service.cs
+  ROS2ExampleRuntime.cs
   INCLUDE_DLLS
   ${_assemblies_dep_dlls}
 )

--- a/src/ros2cs/ros2cs_examples/CMakeLists.txt
+++ b/src/ros2cs/ros2cs_examples/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright 2019-2021 Robotec.ai
+# Modifications Copyright (c) 2026 Jianbin Liu.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# Modifications by Jianbin Liu:
+# - Updated the C# target framework to .NET 8.
 
 cmake_minimum_required(VERSION 3.5)
 
@@ -26,7 +30,8 @@ find_package(builtin_interfaces REQUIRED)
 find_package(dotnet_cmake_module REQUIRED)
 find_package(rosidl_generator_cs REQUIRED)
 
-set(CSHARP_TARGET_FRAMEWORK "netcoreapp6.0")
+# Build examples on .NET 8 while core/common remain netstandard2.0.
+set(CSHARP_TARGET_FRAMEWORK "net8.0")
 set(CSBUILD_TOOL "DotNetCore")
 
 find_package(DotNETExtra REQUIRED)

--- a/src/ros2cs/ros2cs_examples/README.md
+++ b/src/ros2cs/ros2cs_examples/README.md
@@ -1,9 +1,17 @@
 # Ros2Cs Examples
 
+> Modifications Copyright (c) 2026 Jianbin Liu.
+>
+> Modifications by Jianbin Liu:
+> - Corrected example launch commands and PointCloud2 wording.
+> - Documented that examples target .NET 8 in the current maintenance branch.
+
+Current maintenance branch note: `ros2cs_examples` targets `net8.0`. Core/common/generated ros2cs assemblies remain `netstandard2.0`.
+
 ## Examples
 
 *  `ROS2Listener` / `ROS2Talker` - simple string subscriber/publisher test.
-*  `ROS2PerformanceListener` / `ROS2PerformanceTalker` - performance test using PointClound2 data.
+*  `ROS2PerformanceListener` / `ROS2PerformanceTalker` - performance test using PointCloud2 data.
 
 ## Simple subscriber/listener
 
@@ -16,7 +24,7 @@
 2.  Run listener:
   
     ```bash
-    ros2 run ros2cs_examples ros2cs_talker
+    ros2 run ros2cs_examples ros2cs_listener
     ```
 
 3.  Run talker:
@@ -25,7 +33,14 @@
     ros2 run ros2cs_examples ros2cs_talker
     ```
 
-Listener will print out `"I heard: [Hello World: X]` messages which are being send by a talker. 
+    On Windows, use the `.exe` entry points:
+
+    ```powershell
+    ros2 run ros2cs_examples ros2cs_listener.exe
+    ros2 run ros2cs_examples ros2cs_talker.exe
+    ```
+
+Listener will print out `"I heard: [Hello World: X]` messages sent by a talker.
 
 ## Performance test
 
@@ -49,6 +64,13 @@ Listener will print out `"I heard: [Hello World: X]` messages which are being se
     ros2 run ros2cs_examples ros2cs_performance_listener
     ```
 
+    On Windows, use the `.exe` entry points:
+
+    ```powershell
+    ros2 run ros2cs_examples ros2cs_performance_talker.exe
+    ros2 run ros2cs_examples ros2cs_performance_listener.exe
+    ```
+
 5. When asked, set desired sample size (number of messages).
 
 After receiving the desired number of samples, listener will print out average latency and its `Latency of sample size X - avg: Ys, std dev: Zs`
@@ -60,6 +82,6 @@ Hardware spec:
 *  **MEM**: 16GB Ram
 
 | PointCloud size | Sample size | Average rate [Hz] | Average latency [s] | Latency std dev [s] |
-|-|-|-|-|-|-|
+|-|-|-|-|-|
 | 100 000 | 5000 | 719.308 | 0.001591 | 0.000306 |
 | 1 000 000 | 500 | 77.025 | 0.022677 | 0.001607 |

--- a/src/ros2cs/ros2cs_examples/README.md
+++ b/src/ros2cs/ros2cs_examples/README.md
@@ -12,6 +12,7 @@ Current maintenance branch note: `ros2cs_examples` targets `net8.0`. Core/common
 
 *  `ROS2Listener` / `ROS2Talker` - simple string subscriber/publisher test.
 *  `ROS2PerformanceListener` / `ROS2PerformanceTalker` - performance test using PointCloud2 data.
+*  `ROS2Service` / `ROS2Client` - simple `AddTwoInts` service/client test.
 
 ## Simple subscriber/listener
 
@@ -41,6 +42,35 @@ Current maintenance branch note: `ros2cs_examples` targets `net8.0`. Core/common
     ```
 
 Listener will print out `"I heard: [Hello World: X]` messages sent by a talker.
+
+## Simple service/client
+
+1. Build project:
+
+    ```bash
+    ./build.sh
+    ```
+
+2. Run service:
+
+    ```bash
+    ros2 run ros2cs_examples ros2cs_service
+    ```
+
+3. Run client:
+
+    ```bash
+    ros2 run ros2cs_examples ros2cs_client
+    ```
+
+    On Windows, use the `.exe` entry points:
+
+    ```powershell
+    ros2 run ros2cs_examples ros2cs_service.exe
+    ros2 run ros2cs_examples ros2cs_client.exe
+    ```
+
+The service prints the incoming `A` and `B` values. The client sends `7 + 2` and prints `Sum = 9`.
 
 ## Performance test
 

--- a/src/ros2cs/ros2cs_examples/ROS2Client.cs
+++ b/src/ros2cs/ros2cs_examples/ROS2Client.cs
@@ -1,4 +1,8 @@
 // Copyright 2019-2021 Robotec.ai
+// Modifications Copyright (c) 2026 Jianbin Liu.
+//
+// Modifications by Jianbin Liu:
+// - Audited client example metadata during Jazzy/.NET maintenance.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/ros2cs/ros2cs_examples/ROS2Client.cs
+++ b/src/ros2cs/ros2cs_examples/ROS2Client.cs
@@ -16,9 +16,6 @@
 using System;
 using System.Threading;
 using ROS2;
-using std_msgs;
-using sensor_msgs;
-using example_interfaces;
 
 namespace Examples
 {
@@ -28,24 +25,28 @@ namespace Examples
     public static void Main(string[] args)
     {
       Console.WriteLine("Client start");
-      Ros2cs.Init();
-      INode node = Ros2cs.CreateNode("talker");
-      Client<example_interfaces.srv.AddTwoInts_Request, example_interfaces.srv.AddTwoInts_Response> my_client = node.CreateClient<example_interfaces.srv.AddTwoInts_Request, example_interfaces.srv.AddTwoInts_Response>("add_two_ints");
+      using var runtime = new ROS2ExampleRuntime();
+      INode node = Ros2cs.CreateNode("client");
+      using Client<example_interfaces.srv.AddTwoInts_Request, example_interfaces.srv.AddTwoInts_Response> my_client = node.CreateClient<example_interfaces.srv.AddTwoInts_Request, example_interfaces.srv.AddTwoInts_Response>("add_two_ints");
 
-      example_interfaces.srv.AddTwoInts_Request msg = new example_interfaces.srv.AddTwoInts_Request();
+      using var msg = new example_interfaces.srv.AddTwoInts_Request();
       msg.A = 7;
       msg.B = 2;
 
+      DateTime waitDeadline = DateTime.UtcNow + TimeSpan.FromSeconds(30);
       while (!my_client.IsServiceAvailable())
       {
+        if (DateTime.UtcNow >= waitDeadline)
+        {
+          throw new TimeoutException("Timed out waiting for add_two_ints service.");
+        }
         Thread.Sleep(TimeSpan.FromSeconds(0.25));
       }
 
-      example_interfaces.srv.AddTwoInts_Response rsp = my_client.Call(msg);
+      using example_interfaces.srv.AddTwoInts_Response rsp = my_client.Call(msg);
       Console.WriteLine("Sum = " + rsp.Sum);
 
       Console.WriteLine("Client shutdown");
-      Ros2cs.Shutdown();
     }
   }
 }

--- a/src/ros2cs/ros2cs_examples/ROS2ExampleRuntime.cs
+++ b/src/ros2cs/ros2cs_examples/ROS2ExampleRuntime.cs
@@ -1,0 +1,63 @@
+// Copyright 2019-2021 Robotec.ai
+// Modifications Copyright (c) 2026 Jianbin Liu.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using ROS2;
+
+namespace Examples
+{
+  internal sealed class ROS2ExampleRuntime : IDisposable
+  {
+    private readonly object mutex = new object();
+    private bool disposed;
+
+    public ROS2ExampleRuntime()
+    {
+      Ros2cs.Init();
+      Console.CancelKeyPress += OnCancelKeyPress;
+      AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
+    }
+
+    private void OnCancelKeyPress(object sender, ConsoleCancelEventArgs args)
+    {
+      args.Cancel = true;
+      Dispose();
+    }
+
+    private void OnProcessExit(object sender, EventArgs args)
+    {
+      Dispose();
+    }
+
+    public void Dispose()
+    {
+      lock (mutex)
+      {
+        if (disposed)
+        {
+          return;
+        }
+
+        disposed = true;
+        Console.CancelKeyPress -= OnCancelKeyPress;
+        AppDomain.CurrentDomain.ProcessExit -= OnProcessExit;
+        if (Ros2cs.Ok())
+        {
+          Ros2cs.Shutdown();
+        }
+      }
+    }
+  }
+}

--- a/src/ros2cs/ros2cs_examples/ROS2Listener.cs
+++ b/src/ros2cs/ros2cs_examples/ROS2Listener.cs
@@ -3,6 +3,7 @@
 //
 // Modifications by Jianbin Liu:
 // - Audited listener example metadata during Jazzy/.NET maintenance.
+// - Made node lifetime explicit instead of relying only on global shutdown.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,7 +28,7 @@ namespace Examples
     public static void Main(string[] args)
     {
       using var runtime = new ROS2ExampleRuntime();
-      INode node = Ros2cs.CreateNode("listener");
+      using INode node = Ros2cs.CreateNode("listener");
 
       using ISubscription<std_msgs.msg.String> chatter_sub = node.CreateSubscription<std_msgs.msg.String>(
         "chatter", msg => Console.WriteLine("I heard: [" + msg.Data + "]"));

--- a/src/ros2cs/ros2cs_examples/ROS2Listener.cs
+++ b/src/ros2cs/ros2cs_examples/ROS2Listener.cs
@@ -22,14 +22,16 @@ namespace Examples
   {
     public static void Main(string[] args)
     {
-      Ros2cs.Init();
+      using var runtime = new ROS2ExampleRuntime();
       INode node = Ros2cs.CreateNode("listener");
 
-      ISubscription<std_msgs.msg.String> chatter_sub = node.CreateSubscription<std_msgs.msg.String>(
+      using ISubscription<std_msgs.msg.String> chatter_sub = node.CreateSubscription<std_msgs.msg.String>(
         "chatter", msg => Console.WriteLine("I heard: [" + msg.Data + "]"));
 
-      Ros2cs.Spin(node);
-      Ros2cs.Shutdown();
+      while (Ros2cs.Ok())
+      {
+        Ros2cs.SpinOnce(node, 0.1);
+      }
     }
   }
 }

--- a/src/ros2cs/ros2cs_examples/ROS2Listener.cs
+++ b/src/ros2cs/ros2cs_examples/ROS2Listener.cs
@@ -1,4 +1,8 @@
 // Copyright 2019-2021 Robotec.ai
+// Modifications Copyright (c) 2026 Jianbin Liu.
+//
+// Modifications by Jianbin Liu:
+// - Audited listener example metadata during Jazzy/.NET maintenance.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/ros2cs/ros2cs_examples/ROS2PerformanceListener.cs
+++ b/src/ros2cs/ros2cs_examples/ROS2PerformanceListener.cs
@@ -87,8 +87,8 @@ namespace Examples
   {
     public static void Main(string[] args)
     {
-      Ros2cs.Init();
-      Clock clock = new Clock();
+      using var runtime = new ROS2ExampleRuntime();
+      using var clock = new Clock();
       INode node = Ros2cs.CreateNode("perf_listener");
       Console.WriteLine("Enter sample size: ");
       int sampleSize = Convert.ToInt32(Console.ReadLine());
@@ -102,7 +102,7 @@ namespace Examples
 
       using (QualityOfServiceProfile qos = new QualityOfServiceProfile(QosPresetProfile.SENSOR_DATA))
       {
-        ISubscription<sensor_msgs.msg.PointCloud2> chatter_sub = node.CreateSubscription<sensor_msgs.msg.PointCloud2>(
+        using ISubscription<sensor_msgs.msg.PointCloud2> chatter_sub = node.CreateSubscription<sensor_msgs.msg.PointCloud2>(
           "perf_chatter",
           msg =>
           {
@@ -130,7 +130,6 @@ namespace Examples
           Ros2cs.SpinOnce(node, 0.1);
         }
       }
-      Ros2cs.Shutdown();
     }
   }
 }

--- a/src/ros2cs/ros2cs_examples/ROS2PerformanceListener.cs
+++ b/src/ros2cs/ros2cs_examples/ROS2PerformanceListener.cs
@@ -1,4 +1,5 @@
 // Copyright 2019-2021 Robotec.ai
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// Modifications by Jianbin Liu:
+// - Fixed average/stddev calculations before the sample queue reaches capacity.
+// - Replaced callback-side process exit with a normal spin loop shutdown path.
 
 using System;
 using ROS2;
@@ -44,7 +49,7 @@ namespace Examples
       {
         sum += diff;
       }
-      return (double)(sum/this.Size);
+      return this.Count == 0 ? 0.0 : (double)(sum/this.Count);
     }
 
     public InfoStruct MeanAndStdDev()
@@ -58,7 +63,7 @@ namespace Examples
           variance += (diff - mean) * (diff - mean);
         }
         result.mean = mean;
-        result.stdDev = Math.Sqrt((double)(1.0/(this.Size-1)) * variance);
+        result.stdDev = this.Count <= 1 ? 0.0 : Math.Sqrt((double)(1.0/(this.Count-1)) * variance);
         return result;
       }
     }
@@ -93,32 +98,38 @@ namespace Examples
 
       RosTime timeStamp = new RosTime();
       int counter = 0;
+      bool done = false;
 
-      QualityOfServiceProfile qos = new QualityOfServiceProfile(QosPresetProfile.SENSOR_DATA);
-      ISubscription<sensor_msgs.msg.PointCloud2> chatter_sub = node.CreateSubscription<sensor_msgs.msg.PointCloud2>(
-        "perf_chatter",
-        msg =>
-        {
-          RosTime timeNow = clock.Now;
-          timeStamp.nanosec = msg.Header.Stamp.Nanosec;
-          timeStamp.sec = msg.Header.Stamp.Sec;
-          var diff = timeNow.Seconds - timeStamp.Seconds;
-
-          queue.Enqueue(diff);
-          counter++;
-
-          if (counter == queue.Size)
+      using (QualityOfServiceProfile qos = new QualityOfServiceProfile(QosPresetProfile.SENSOR_DATA))
+      {
+        ISubscription<sensor_msgs.msg.PointCloud2> chatter_sub = node.CreateSubscription<sensor_msgs.msg.PointCloud2>(
+          "perf_chatter",
+          msg =>
           {
-            counter = 0;
-            Console.Clear();
-            var result = queue.MeanAndStdDev();
-            Console.WriteLine("Latency of sample size {0} - avg: {1:F6}s, std dev: {2:F10}s", sampleSize, result.mean, result.stdDev);
-            Environment.Exit(0);
-          }
-        },
-        qos);
+            RosTime timeNow = clock.Now;
+            timeStamp.nanosec = msg.Header.Stamp.Nanosec;
+            timeStamp.sec = msg.Header.Stamp.Sec;
+            var diff = timeNow.Seconds - timeStamp.Seconds;
 
-      Ros2cs.Spin(node);
+            queue.Enqueue(diff);
+            counter++;
+
+            if (counter == queue.Size)
+            {
+              counter = 0;
+              Console.Clear();
+              var result = queue.MeanAndStdDev();
+              Console.WriteLine("Latency of sample size {0} - avg: {1:F6}s, std dev: {2:F10}s", sampleSize, result.mean, result.stdDev);
+              done = true;
+            }
+          },
+          qos);
+
+        while (!done && Ros2cs.Ok())
+        {
+          Ros2cs.SpinOnce(node, 0.1);
+        }
+      }
       Ros2cs.Shutdown();
     }
   }

--- a/src/ros2cs/ros2cs_examples/ROS2PerformanceTalker.cs
+++ b/src/ros2cs/ros2cs_examples/ROS2PerformanceTalker.cs
@@ -3,6 +3,7 @@
 //
 // Modifications by Jianbin Liu:
 // - Audited performance talker example metadata during Jazzy/.NET maintenance.
+// - Added explicit disposal for nested PointField message wrappers.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -75,6 +76,20 @@ namespace Examples
       return message;
     }
 
+    /// <summary>Dispose nested PointField wrappers owned by the reusable PointCloud2 example message.</summary>
+    private static void DisposePointFields(sensor_msgs.msg.PointCloud2 message)
+    {
+      if (message?.Fields == null)
+      {
+        return;
+      }
+
+      foreach (sensor_msgs.msg.PointField field in message.Fields)
+      {
+        field?.Dispose();
+      }
+    }
+
     public static void Main(string[] args)
     {
       using var runtime = new ROS2ExampleRuntime();
@@ -88,18 +103,25 @@ namespace Examples
       using sensor_msgs.msg.PointCloud2 msg = PrepMessage(messageSize);
       // System.Random rand = new System.Random();
 
-      while (Ros2cs.Ok())
+      try
       {
-        var nowTime = clock.Now;
-        msg.UpdateHeaderTime(nowTime.sec, nowTime.nanosec);
-
-        // Remove this benchmark if you want to measure maximum throughput for smallest messages
-        using (var bench = new Benchmark("Publish"))
+        while (Ros2cs.Ok())
         {
-          // If we want to test changing sizes:
-          // msg = PrepMessage(rand.Next() / 1000);
-          pc_pub.Publish(msg);
+          var nowTime = clock.Now;
+          msg.UpdateHeaderTime(nowTime.sec, nowTime.nanosec);
+
+          // Remove this benchmark if you want to measure maximum throughput for smallest messages
+          using (var bench = new Benchmark("Publish"))
+          {
+            // If we want to test changing sizes:
+            // msg = PrepMessage(rand.Next() / 1000);
+            pc_pub.Publish(msg);
+          }
         }
+      }
+      finally
+      {
+        DisposePointFields(msg);
       }
     }
   }

--- a/src/ros2cs/ros2cs_examples/ROS2PerformanceTalker.cs
+++ b/src/ros2cs/ros2cs_examples/ROS2PerformanceTalker.cs
@@ -1,4 +1,8 @@
 // Copyright 2019-2021 Robotec.ai
+// Modifications Copyright (c) 2026 Jianbin Liu.
+//
+// Modifications by Jianbin Liu:
+// - Audited performance talker example metadata during Jazzy/.NET maintenance.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/ros2cs/ros2cs_examples/ROS2PerformanceTalker.cs
+++ b/src/ros2cs/ros2cs_examples/ROS2PerformanceTalker.cs
@@ -21,8 +21,6 @@ namespace Examples
   /// <summary> A talker class meant to gauge performance of Ros2cs </summary>
   public class ROS2PerformanceTalker
   {
-    private static Clock clock = new Clock();
-
     private static void AssignField(ref sensor_msgs.msg.PointField pf, string n, uint off, byte dt, uint count)
     {
       pf.Name = n;
@@ -75,14 +73,15 @@ namespace Examples
 
     public static void Main(string[] args)
     {
-      Ros2cs.Init();
+      using var runtime = new ROS2ExampleRuntime();
+      using var clock = new Clock();
       INode node = Ros2cs.CreateNode("perf_talker");
-      QualityOfServiceProfile qos = new QualityOfServiceProfile(QosPresetProfile.SENSOR_DATA);
-      IPublisher<sensor_msgs.msg.PointCloud2> pc_pub = node.CreatePublisher<sensor_msgs.msg.PointCloud2>("perf_chatter", qos);
+      using var qos = new QualityOfServiceProfile(QosPresetProfile.SENSOR_DATA);
+      using IPublisher<sensor_msgs.msg.PointCloud2> pc_pub = node.CreatePublisher<sensor_msgs.msg.PointCloud2>("perf_chatter", qos);
 
       Console.WriteLine("Enter PC2 data size: ");
       int messageSize = Convert.ToInt32(Console.ReadLine());
-      sensor_msgs.msg.PointCloud2 msg = PrepMessage(messageSize);
+      using sensor_msgs.msg.PointCloud2 msg = PrepMessage(messageSize);
       // System.Random rand = new System.Random();
 
       while (Ros2cs.Ok())
@@ -98,7 +97,6 @@ namespace Examples
           pc_pub.Publish(msg);
         }
       }
-      Ros2cs.Shutdown();
     }
   }
 }

--- a/src/ros2cs/ros2cs_examples/ROS2Service.cs
+++ b/src/ros2cs/ros2cs_examples/ROS2Service.cs
@@ -3,6 +3,7 @@
 //
 // Modifications by Jianbin Liu:
 // - Audited service example metadata during Jazzy/.NET maintenance.
+// - Made node lifetime explicit instead of relying only on global shutdown.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,7 +30,7 @@ namespace Examples
     {
       Console.WriteLine("Service start");
       using var runtime = new ROS2ExampleRuntime();
-      INode node = Ros2cs.CreateNode("service");
+      using INode node = Ros2cs.CreateNode("service");
       using IService<example_interfaces.srv.AddTwoInts_Request, example_interfaces.srv.AddTwoInts_Response> my_service =
         node.CreateService<example_interfaces.srv.AddTwoInts_Request, example_interfaces.srv.AddTwoInts_Response>(
           "add_two_ints", recv_callback);

--- a/src/ros2cs/ros2cs_examples/ROS2Service.cs
+++ b/src/ros2cs/ros2cs_examples/ROS2Service.cs
@@ -1,4 +1,8 @@
 // Copyright 2019-2021 Robotec.ai
+// Modifications Copyright (c) 2026 Jianbin Liu.
+//
+// Modifications by Jianbin Liu:
+// - Audited service example metadata during Jazzy/.NET maintenance.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/ros2cs/ros2cs_examples/ROS2Service.cs
+++ b/src/ros2cs/ros2cs_examples/ROS2Service.cs
@@ -14,7 +14,6 @@
 
 
 using System;
-using System.Collections.Generic;
 using ROS2;
 
 namespace Examples
@@ -22,24 +21,25 @@ namespace Examples
   /// <summary> A simple service class to illustrate Ros2cs in action </summary>
   public class ROS2Service
   {
-    public static IService<example_interfaces.srv.AddTwoInts_Request, example_interfaces.srv.AddTwoInts_Response> my_service;
-
     public static void Main(string[] args)
     {
       Console.WriteLine("Service start");
-      Ros2cs.Init();
+      using var runtime = new ROS2ExampleRuntime();
       INode node = Ros2cs.CreateNode("service");
-      my_service = node.CreateService<example_interfaces.srv.AddTwoInts_Request, example_interfaces.srv.AddTwoInts_Response>(
-        "add_two_ints", recv_callback);
+      using IService<example_interfaces.srv.AddTwoInts_Request, example_interfaces.srv.AddTwoInts_Response> my_service =
+        node.CreateService<example_interfaces.srv.AddTwoInts_Request, example_interfaces.srv.AddTwoInts_Response>(
+          "add_two_ints", recv_callback);
 
-      Ros2cs.Spin(node);
-      Ros2cs.Shutdown();
+      while (Ros2cs.Ok())
+      {
+        Ros2cs.SpinOnce(node, 0.1);
+      }
     }
 
     public static example_interfaces.srv.AddTwoInts_Response recv_callback( example_interfaces.srv.AddTwoInts_Request msg )
     {
       Console.WriteLine ("Incoming Service Request A=" + msg.A + " B=" + msg.B);
-      example_interfaces.srv.AddTwoInts_Response response = new example_interfaces.srv.AddTwoInts_Response();
+      var response = new example_interfaces.srv.AddTwoInts_Response();
       response.Sum = msg.A + msg.B;
       return response;
     }

--- a/src/ros2cs/ros2cs_examples/ROS2Talker.cs
+++ b/src/ros2cs/ros2cs_examples/ROS2Talker.cs
@@ -26,10 +26,10 @@ namespace Examples
     public static void Main(string[] args)
     {
       Console.WriteLine("Talker starting");
-      Ros2cs.Init();
+      using var runtime = new ROS2ExampleRuntime();
       INode node = Ros2cs.CreateNode("talker");
-      Publisher<std_msgs.msg.String> chatter_pub = node.CreatePublisher<std_msgs.msg.String>("chatter");
-      std_msgs.msg.String msg = new std_msgs.msg.String();
+      using Publisher<std_msgs.msg.String> chatter_pub = node.CreatePublisher<std_msgs.msg.String>("chatter");
+      using var msg = new std_msgs.msg.String();
 
       int i = 1;
 
@@ -41,7 +41,6 @@ namespace Examples
         Console.WriteLine(msg.Data);
         chatter_pub.Publish(msg);
       }
-      Ros2cs.Shutdown();
     }
   }
 }

--- a/src/ros2cs/ros2cs_examples/ROS2Talker.cs
+++ b/src/ros2cs/ros2cs_examples/ROS2Talker.cs
@@ -1,4 +1,8 @@
 // Copyright 2019-2021 Robotec.ai
+// Modifications Copyright (c) 2026 Jianbin Liu.
+//
+// Modifications by Jianbin Liu:
+// - Audited talker example metadata during Jazzy/.NET maintenance.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/ros2cs/ros2cs_examples/ROS2Talker.cs
+++ b/src/ros2cs/ros2cs_examples/ROS2Talker.cs
@@ -3,6 +3,7 @@
 //
 // Modifications by Jianbin Liu:
 // - Audited talker example metadata during Jazzy/.NET maintenance.
+// - Made node lifetime explicit instead of relying only on global shutdown.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,7 +32,7 @@ namespace Examples
     {
       Console.WriteLine("Talker starting");
       using var runtime = new ROS2ExampleRuntime();
-      INode node = Ros2cs.CreateNode("talker");
+      using INode node = Ros2cs.CreateNode("talker");
       using Publisher<std_msgs.msg.String> chatter_pub = node.CreatePublisher<std_msgs.msg.String>("chatter");
       using var msg = new std_msgs.msg.String();
 

--- a/src/ros2cs/ros2cs_examples/package.xml
+++ b/src/ros2cs/ros2cs_examples/package.xml
@@ -9,8 +9,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <buildtool_depend>dotnet_cmake_module</buildtool_depend>
-  <buildtool_depend>rosidl_generator_cs</buildtool_depend>
-  <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
 
   <build_depend>example_interfaces</build_depend>
   <build_depend>builtin_interfaces</build_depend>

--- a/src/ros2cs/ros2cs_tests/CMakeLists.txt
+++ b/src/ros2cs/ros2cs_tests/CMakeLists.txt
@@ -1,3 +1,11 @@
+#
+# Modifications Copyright (c) 2026 Jianbin Liu.
+#
+# Modifications by Jianbin Liu:
+# - Updated the C# test target framework to .NET 8.
+# - Preserved the final newline for consistent generated build files.
+#
+
 cmake_minimum_required(VERSION 3.6)
 project(ros2cs_tests)
 
@@ -6,7 +14,8 @@ if(BUILD_TESTING)
   find_package(ament_cmake REQUIRED)
   find_package(dotnet_cmake_module REQUIRED)
 
-  set(CSHARP_TARGET_FRAMEWORK "netcoreapp6.0")
+  # Build tests on .NET 8 while core/common remain netstandard2.0.
+  set(CSHARP_TARGET_FRAMEWORK "net8.0")
 
   set(CSBUILD_TOOL "DotNetCore")
   find_package(DotNETExtra REQUIRED)

--- a/src/ros2cs/ros2cs_tests/CMakeLists.txt
+++ b/src/ros2cs/ros2cs_tests/CMakeLists.txt
@@ -4,6 +4,7 @@
 # Modifications by Jianbin Liu:
 # - Updated the C# test target framework to .NET 8.
 # - Preserved the final newline for consistent generated build files.
+# - Added a generated message finalizer child-process probe.
 #
 
 cmake_minimum_required(VERSION 3.6)
@@ -55,6 +56,20 @@ if(BUILD_TESTING)
     ${TESTS_SRC}
     INCLUDE_DLLS
     ${ASSEMBLIES_DEP_DLLS}
+  )
+
+  set(FINALIZER_PROBE_TARGET ros2cs_generated_message_finalizer_probe)
+  add_dotnet_executable(${FINALIZER_PROBE_TARGET}
+    src/GeneratedMessageFinalizerProbe.cs
+    INCLUDE_DLLS
+    ${ASSEMBLIES_DEP_DLLS}
+  )
+
+  ament_add_test(
+    ${FINALIZER_PROBE_TARGET}_test
+    GENERATE_RESULT_FOR_RETURN_CODE_ZERO
+    WORKING_DIRECTORY "${DOTNET_OUTPUT_PATH}"
+    COMMAND dotnet "${FINALIZER_PROBE_TARGET}.dll"
   )
 
   install_dotnet(${PROJECT_NAME} DESTINATION lib/tests)

--- a/src/ros2cs/ros2cs_tests/CMakeLists.txt
+++ b/src/ros2cs/ros2cs_tests/CMakeLists.txt
@@ -5,6 +5,7 @@
 # - Updated the C# test target framework to .NET 8.
 # - Preserved the final newline for consistent generated build files.
 # - Added a generated message finalizer child-process probe.
+# - Added isolated ros2cs_common primitive coverage.
 #
 
 cmake_minimum_required(VERSION 3.6)
@@ -46,6 +47,7 @@ if(BUILD_TESTING)
     src/MessagesTest.cs
     src/NodeTest.cs
     src/NativeMethodsTest.cs
+    src/Ros2csCommonTest.cs
     src/ClientTest.cs
     src/ServiceTest.cs
     src/SubscriptionTest.cs

--- a/src/ros2cs/ros2cs_tests/CMakeLists.txt
+++ b/src/ros2cs/ros2cs_tests/CMakeLists.txt
@@ -10,6 +10,7 @@ cmake_minimum_required(VERSION 3.6)
 project(ros2cs_tests)
 
 if(BUILD_TESTING)
+  find_package(ros2cs_common REQUIRED)
   find_package(ros2cs_core REQUIRED)
   find_package(ament_cmake REQUIRED)
   find_package(dotnet_cmake_module REQUIRED)
@@ -43,7 +44,7 @@ if(BUILD_TESTING)
     src/LargeMessageTest.cs
     src/MessagesTest.cs
     src/NodeTest.cs
-    src/NativeMetodsTest.cs
+    src/NativeMethodsTest.cs
     src/ClientTest.cs
     src/ServiceTest.cs
     src/SubscriptionTest.cs

--- a/src/ros2cs/ros2cs_tests/package.xml
+++ b/src/ros2cs/ros2cs_tests/package.xml
@@ -12,10 +12,7 @@
 
   <buildtool_export_depend>ament_cmake</buildtool_export_depend>
 
-  <build_depend>ros2cs_core</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>example_interfaces</build_depend>
-
+  <test_depend>ros2cs_common</test_depend>
   <test_depend>ros2cs_core</test_depend>
   <test_depend>std_msgs</test_depend>
   <test_depend>test_msgs</test_depend>

--- a/src/ros2cs/ros2cs_tests/src/ClientTest.cs
+++ b/src/ros2cs/ros2cs_tests/src/ClientTest.cs
@@ -15,6 +15,7 @@
 
 // Modifications by Jianbin Liu:
 // - Added disposed client availability coverage.
+// - Added synchronous call reentry guard coverage.
 
 using System;
 using System.Linq;
@@ -108,6 +109,34 @@ namespace ROS2.Test
                 Volatile.Write(ref spinDone, true);
                 Assert.That(spinTask.Wait(TimeSpan.FromSeconds(1)), Is.True);
             }
+        }
+
+        [Test]
+        public void ClientCallFromSpinCallbackThrows()
+        {
+            using var service = Node.CreateService<AddTwoInts_Request, AddTwoInts_Response>(
+                SERVICE_NAME,
+                HandleRequest
+            );
+            using var publisher = Node.CreatePublisher<std_msgs.msg.Int32>("client_reentry_topic");
+            InvalidOperationException callException = null;
+            bool callbackTriggered = false;
+            Node.CreateSubscription<std_msgs.msg.Int32>(
+                "client_reentry_topic",
+                msg =>
+                {
+                    callbackTriggered = true;
+                    callException = Assert.Throws<InvalidOperationException>(
+                        () => Client.Call(CreateRequest(1, 2), TimeSpan.FromMilliseconds(100)));
+                });
+
+            using var publishedMsg = new std_msgs.msg.Int32();
+            publishedMsg.Data = 1;
+            publisher.Publish(publishedMsg);
+            SpinUntil(() => callbackTriggered, "Timed out waiting for reentry test callback.");
+
+            Assert.That(callException, Is.Not.Null);
+            Assert.That(callException.Message, Does.Contain("Synchronous Client.Call cannot be used from a spin callback"));
         }
 
         [Test]

--- a/src/ros2cs/ros2cs_tests/src/ClientTest.cs
+++ b/src/ros2cs/ros2cs_tests/src/ClientTest.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using example_interfaces.srv;
@@ -29,6 +30,7 @@ namespace ROS2.Test
     public class ClientTest
     {
         private static readonly string SERVICE_NAME = "test_service";
+        private static readonly TimeSpan SpinTimeout = TimeSpan.FromSeconds(5);
 
         private INode Node;
 
@@ -45,8 +47,10 @@ namespace ROS2.Test
         [TearDown]
         public void TearDown()
         {
-            Node.Dispose();
-            Ros2cs.Shutdown();
+            if (Ros2cs.Ok())
+            {
+                Ros2cs.Shutdown();
+            }
         }
 
         private AddTwoInts_Request CreateRequest(int a, int b)
@@ -64,6 +68,48 @@ namespace ROS2.Test
             return response;
         }
 
+        private void SpinUntil(Func<bool> condition, string timeoutMessage)
+        {
+            DateTime deadline = DateTime.UtcNow + SpinTimeout;
+            while (!condition())
+            {
+                if (DateTime.UtcNow >= deadline)
+                {
+                    Assert.Fail(timeoutMessage);
+                }
+                Ros2cs.SpinOnce(Node, 0.1);
+            }
+        }
+
+        [Test]
+        public void ClientCall()
+        {
+            using var service = Node.CreateService<AddTwoInts_Request, AddTwoInts_Response>(
+                SERVICE_NAME,
+                HandleRequest
+            );
+
+            bool spinDone = false;
+            Task spinTask = Task.Run(() =>
+            {
+                while (!Volatile.Read(ref spinDone))
+                {
+                    Ros2cs.SpinOnce(Node, 0.1);
+                }
+            });
+
+            try
+            {
+                using AddTwoInts_Response response = Client.Call(CreateRequest(8, 13), SpinTimeout);
+                Assert.That(response.Sum, Is.EqualTo(21));
+            }
+            finally
+            {
+                Volatile.Write(ref spinDone, true);
+                Assert.That(spinTask.Wait(TimeSpan.FromSeconds(1)), Is.True);
+            }
+        }
+
         [Test]
         public void ClientCallAsync()
         {
@@ -72,10 +118,7 @@ namespace ROS2.Test
                 HandleRequest
             );
             var task = Client.CallAsync(CreateRequest(42, 3));
-            while (!task.IsCompleted)
-            {
-                Ros2cs.SpinOnce(Node, 0.1);
-            }
+            SpinUntil(() => task.IsCompleted, "Timed out waiting for service response.");
             Assert.That(task.Result.Sum, Is.EqualTo(45));
         }
 
@@ -90,25 +133,22 @@ namespace ROS2.Test
                 .Range(0, 10)
                 .Select(i => Client.CallAsync(CreateRequest(i, 100 - i)))
                 .ToArray();
-            while (!tasks.All(task => task.IsCompleted))
-            {
-                Ros2cs.SpinOnce(Node, 0.1);
-            }
+            SpinUntil(() => tasks.All(task => task.IsCompleted), "Timed out waiting for concurrent service responses.");
             Assert.That(tasks.Select(task => task.Result.Sum), Is.All.EqualTo(100));
         }
 
         [Test]
         public void ClientWaitForService()
         {
-            Assert.That(!Client.IsServiceAvailable());
+            Assert.That(Client.IsServiceAvailable(), Is.False);
             {
                 using var service = Node.CreateService<AddTwoInts_Request, AddTwoInts_Response>(
                     SERVICE_NAME,
                     HandleRequest
                 );
-                Assert.That(Client.IsServiceAvailable());
+                Assert.That(Client.IsServiceAvailable(), Is.True);
             }
-            Assert.That(!Client.IsServiceAvailable());
+            Assert.That(Client.IsServiceAvailable(), Is.False);
         }
 
         [Test]
@@ -122,7 +162,7 @@ namespace ROS2.Test
         [Test]
         public void DisposedClientHandling()
         {
-            Assert.That(!Client.IsDisposed);
+            Assert.That(Client.IsDisposed, Is.False);
             Client.Dispose();
             Assert.That(Client.IsDisposed);
             Assert.DoesNotThrow(() => { Ros2cs.SpinOnce(Node, 0.1); });
@@ -168,10 +208,7 @@ namespace ROS2.Test
 
             Assert.That(this.Client.PendingRequests.Count, Is.EqualTo(3));
 
-            while (!tasks.Any(task => task.IsCompleted))
-            {
-                Ros2cs.SpinOnce(Node, 0.1);
-            }
+            SpinUntil(() => tasks.Any(task => task.IsCompleted), "Timed out waiting for any pending request to complete.");
 
             int completed = tasks.Where(task => task.IsCompletedSuccessfully).Count();
 
@@ -186,6 +223,7 @@ namespace ROS2.Test
             Task pendingTask = this.Client.CallAsync(this.CreateRequest(3, 4));
 
             Assert.That(requests.Keys, Is.EquivalentTo(this.Client.PendingRequests.Keys));
+            Assert.That(this.Client.Cancel(pendingTask), Is.True);
         }
 
         [Test]
@@ -199,10 +237,7 @@ namespace ROS2.Test
             );
             Task finishedTask = this.Client.CallAsync(this.CreateRequest(3, 4));
 
-            while (!finishedTask.IsCompleted)
-            {
-                Ros2cs.SpinOnce(Node, 0.1);
-            }
+            SpinUntil(() => finishedTask.IsCompleted, "Timed out waiting for finished request before cancel check.");
 
             Assert.That(this.Client.Cancel(finishedTask), Is.False);
 

--- a/src/ros2cs/ros2cs_tests/src/ClientTest.cs
+++ b/src/ros2cs/ros2cs_tests/src/ClientTest.cs
@@ -1,4 +1,5 @@
 // Copyright 2019-2021 Robotec.ai
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +12,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// Modifications by Jianbin Liu:
+// - Added disposed client availability coverage.
 
 using System;
 using System.Linq;
@@ -105,6 +109,14 @@ namespace ROS2.Test
                 Assert.That(Client.IsServiceAvailable());
             }
             Assert.That(!Client.IsServiceAvailable());
+        }
+
+        [Test]
+        public void ClientWaitForServiceAfterDisposeReturnsFalse()
+        {
+            Client.Dispose();
+
+            Assert.That(Client.IsServiceAvailable(), Is.False);
         }
 
         [Test]

--- a/src/ros2cs/ros2cs_tests/src/ClockTest.cs
+++ b/src/ros2cs/ros2cs_tests/src/ClockTest.cs
@@ -17,6 +17,7 @@
 // Modifications by Jianbin Liu:
 // - Added negative nanosecond normalization and overflow coverage.
 // - Split pure RosTime conversion tests away from ROS-initialized Clock tests.
+// - Added clock lifecycle coverage across shutdown, reinit, and dispose.
 
 using System;
 using NUnit.Framework;
@@ -54,6 +55,38 @@ namespace ROS2.Test
             using var clock = new Clock();
             RosTime timeNow = clock.Now;
             Assert.That(timeNow.sec, Is.GreaterThan(0));
+        }
+
+        [Test]
+        public void ClockGetNowAfterShutdown()
+        {
+            using var clock = new Clock();
+            Ros2cs.Shutdown();
+
+            RosTime timeNow = clock.Now;
+
+            Assert.That(timeNow.sec, Is.GreaterThan(0));
+        }
+
+        [Test]
+        public void ClockGetNowAfterShutdownAndReinit()
+        {
+            using var clock = new Clock();
+            Ros2cs.Shutdown();
+            Ros2cs.Init();
+
+            RosTime timeNow = clock.Now;
+
+            Assert.That(timeNow.sec, Is.GreaterThan(0));
+        }
+
+        [Test]
+        public void ClockGetNowAfterDisposeThrows()
+        {
+            var clock = new Clock();
+            clock.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => { var _ = clock.Now; });
         }
     }
 

--- a/src/ros2cs/ros2cs_tests/src/ClockTest.cs
+++ b/src/ros2cs/ros2cs_tests/src/ClockTest.cs
@@ -15,8 +15,8 @@
 // limitations under the License.
 
 // Modifications by Jianbin Liu:
-// - Added setup/teardown guard for tests that do not require ROS initialization.
 // - Added negative nanosecond normalization and overflow coverage.
+// - Split pure RosTime conversion tests away from ROS-initialized Clock tests.
 
 using System;
 using NUnit.Framework;
@@ -26,52 +26,43 @@ namespace ROS2.Test
     [TestFixture]
     public class ClockTest
     {
-        // Tracks whether the current test initialized ROS so teardown can skip utility-only tests.
-        private bool rosInitialized;
-
         [SetUp]
         public void SetUp()
         {
-            string testName = TestContext.CurrentContext.Test.Name;
-            if (testName == nameof(RosTimeFromNegativeNanosecondsIsNormalized) ||
-                testName == nameof(RosTimeOverflowThrows))
-            {
-                return;
-            }
-
             Ros2cs.Init();
-            rosInitialized = true;
         }
 
         [TearDown]
         public void TearDown()
         {
-            if (rosInitialized)
+            if (Ros2cs.Ok())
             {
                 Ros2cs.Shutdown();
-                rosInitialized = false;
             }
         }
 
         [Test]
         public void CreateClock()
         {
-            Clock clock = new Clock();
+            using var clock = new Clock();
+            Assert.That(clock.IsDisposed, Is.False);
         }
 
         [Test]
         public void ClockGetNow()
         {
-            Clock clock = new Clock();
+            using var clock = new Clock();
             RosTime timeNow = clock.Now;
-            Assert.That(timeNow.sec, Is.Not.EqualTo(0));
+            Assert.That(timeNow.sec, Is.GreaterThan(0));
         }
+    }
 
+    [TestFixture]
+    public class RosTimeTest
+    {
         [Test]
         public void RosTimeSeconds()
         {
-            Clock clock = new Clock();
-
             RosTime oneSecond = new RosTime { sec = 1, nanosec = 0 };
             Assert.That(oneSecond.Seconds, Is.EqualTo(1.0d));
 

--- a/src/ros2cs/ros2cs_tests/src/ClockTest.cs
+++ b/src/ros2cs/ros2cs_tests/src/ClockTest.cs
@@ -1,5 +1,6 @@
 // Copyright 2019-2021 Robotec.ai
 // Copyright 2019 Dyno Robotics (by Samuel Lindgren samuel@dynorobotics.se)
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,6 +14,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Modifications by Jianbin Liu:
+// - Added setup/teardown guard for tests that do not require ROS initialization.
+// - Added negative nanosecond normalization coverage.
+
 using NUnit.Framework;
 
 namespace ROS2.Test
@@ -20,16 +25,29 @@ namespace ROS2.Test
     [TestFixture]
     public class ClockTest
     {
+        // Tracks whether the current test initialized ROS so teardown can skip utility-only tests.
+        private bool rosInitialized;
+
         [SetUp]
         public void SetUp()
         {
+            if (TestContext.CurrentContext.Test.Name == nameof(RosTimeFromNegativeNanosecondsIsNormalized))
+            {
+                return;
+            }
+
             Ros2cs.Init();
+            rosInitialized = true;
         }
 
         [TearDown]
         public void TearDown()
         {
-            Ros2cs.Shutdown();
+            if (rosInitialized)
+            {
+                Ros2cs.Shutdown();
+                rosInitialized = false;
+            }
         }
 
         [Test]
@@ -56,6 +74,16 @@ namespace ROS2.Test
 
             RosTime twoPointSix = new RosTime { sec = 2, nanosec = 600000000 };
             Assert.That(twoPointSix.Seconds, Is.EqualTo(2.6d));
+        }
+
+        /// <summary>Negative nanoseconds should normalize to the previous second plus positive nanoseconds.</summary>
+        [Test]
+        public void RosTimeFromNegativeNanosecondsIsNormalized()
+        {
+            RosTime time = Clock.FromNanoseconds(-1);
+
+            Assert.That(time.sec, Is.EqualTo(-1));
+            Assert.That(time.nanosec, Is.EqualTo(999999999));
         }
     }
 }

--- a/src/ros2cs/ros2cs_tests/src/ClockTest.cs
+++ b/src/ros2cs/ros2cs_tests/src/ClockTest.cs
@@ -16,8 +16,9 @@
 
 // Modifications by Jianbin Liu:
 // - Added setup/teardown guard for tests that do not require ROS initialization.
-// - Added negative nanosecond normalization coverage.
+// - Added negative nanosecond normalization and overflow coverage.
 
+using System;
 using NUnit.Framework;
 
 namespace ROS2.Test
@@ -31,7 +32,9 @@ namespace ROS2.Test
         [SetUp]
         public void SetUp()
         {
-            if (TestContext.CurrentContext.Test.Name == nameof(RosTimeFromNegativeNanosecondsIsNormalized))
+            string testName = TestContext.CurrentContext.Test.Name;
+            if (testName == nameof(RosTimeFromNegativeNanosecondsIsNormalized) ||
+                testName == nameof(RosTimeOverflowThrows))
             {
                 return;
             }
@@ -84,6 +87,15 @@ namespace ROS2.Test
 
             Assert.That(time.sec, Is.EqualTo(-1));
             Assert.That(time.nanosec, Is.EqualTo(999999999));
+        }
+
+        /// <summary>builtin_interfaces/msg/Time stores seconds as int32, so overflow must fail explicitly.</summary>
+        [Test]
+        public void RosTimeOverflowThrows()
+        {
+            long overflowingNanoseconds = ((long)int.MaxValue + 1L) * 1000000000L;
+
+            Assert.Throws<OverflowException>(() => Clock.FromNanoseconds(overflowingNanoseconds));
         }
     }
 }

--- a/src/ros2cs/ros2cs_tests/src/GeneratedMessageFinalizerProbe.cs
+++ b/src/ros2cs/ros2cs_tests/src/GeneratedMessageFinalizerProbe.cs
@@ -1,0 +1,64 @@
+// Modifications Copyright (c) 2026 Jianbin Liu.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Modifications by Jianbin Liu:
+// - Added a child-process probe for generated message finalizer safety.
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace ROS2.Test
+{
+    /// <summary>
+    /// Standalone process used by CTest to prove leaked generated messages do not crash during finalizer processing.
+    /// </summary>
+    internal static class GeneratedMessageFinalizerProbe
+    {
+        /// <summary>Create a generated message, drop it without Dispose, force finalizers, and return the process result.</summary>
+        public static int Main(string[] args)
+        {
+            try
+            {
+                CreateLeakedGeneratedString();
+                ForceFinalizerSweep();
+                Console.WriteLine("GENERATED_MESSAGE_FINALIZER_PROBE_PASS");
+                return 0;
+            }
+            catch (Exception e)
+            {
+                Console.Error.WriteLine(e);
+                return 1;
+            }
+        }
+
+        /// <summary>Create a generated string message with an allocated native handle, then intentionally leak ownership.</summary>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void CreateLeakedGeneratedString()
+        {
+            std_msgs.msg.String msg = new std_msgs.msg.String();
+            msg.Data = "generated_message_finalizer_probe";
+            msg.WriteNativeMessage();
+        }
+
+        /// <summary>Force finalizers in this child process so native crashes do not kill the NUnit runner.</summary>
+        private static void ForceFinalizerSweep()
+        {
+            for (int i = 0; i < 3; ++i)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+            }
+        }
+    }
+}

--- a/src/ros2cs/ros2cs_tests/src/InitShutdownTest.cs
+++ b/src/ros2cs/ros2cs_tests/src/InitShutdownTest.cs
@@ -4,6 +4,7 @@
 //
 // Modifications by Jianbin Liu:
 // - Audited init/shutdown regression tests after lifecycle hardening.
+// - Added lifecycle stress coverage and clarified spin timeout semantics.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -69,6 +70,20 @@ namespace ROS2.Test
         }
 
         [Test]
+        public void InitShutdownStress()
+        {
+            for (int i = 0; i < 50; ++i)
+            {
+                Ros2cs.Init();
+                Assert.That(Ros2cs.Ok(), Is.True);
+                Ros2cs.Shutdown();
+                Assert.That(Ros2cs.Ok(), Is.False);
+            }
+
+            Assert.That(Ros2cs.Ok(), Is.False);
+        }
+
+        [Test]
         public void DoubleInit()
         {
             Ros2cs.Init();
@@ -109,6 +124,7 @@ namespace ROS2.Test
                     "subscription_test_topic",
                     (msg) => { throw new InvalidOperationException("subscription callback was triggered"); }
                 );
+                // True means the non-empty wait set was populated and waited on; no message is expected here.
                 Assert.That(Ros2cs.SpinOnce(node), Is.True);
             }
             finally

--- a/src/ros2cs/ros2cs_tests/src/InitShutdownTest.cs
+++ b/src/ros2cs/ros2cs_tests/src/InitShutdownTest.cs
@@ -1,5 +1,9 @@
 ﻿// Copyright 2019 Dyno Robotics (by Samuel Lindgren samuel@dynorobotics.se)
 // Copyright 2019-2021 Robotec.ai
+// Modifications Copyright (c) 2026 Jianbin Liu.
+//
+// Modifications by Jianbin Liu:
+// - Audited init/shutdown regression tests after lifecycle hardening.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/ros2cs/ros2cs_tests/src/InitShutdownTest.cs
+++ b/src/ros2cs/ros2cs_tests/src/InitShutdownTest.cs
@@ -21,33 +21,47 @@ namespace ROS2.Test
     [TestFixture]
     public class InitShutdownTest
     {
+        [TearDown]
+        public void TearDown()
+        {
+            if (Ros2cs.Ok())
+            {
+                Ros2cs.Shutdown();
+            }
+        }
+
         [Test]
         public void Init()
         {
             Ros2cs.Init();
-            try
-            {
-                Ros2cs.Shutdown();
-            }
-            catch (RuntimeError)
-            {
-            }
+            Assert.That(Ros2cs.Ok(), Is.True);
+
+            Assert.DoesNotThrow(() => Ros2cs.Shutdown());
+            Assert.That(Ros2cs.Ok(), Is.False);
         }
 
         [Test]
         public void InitShutdown()
         {
             Ros2cs.Init();
+            Assert.That(Ros2cs.Ok(), Is.True);
+
             Ros2cs.Shutdown();
+            Assert.That(Ros2cs.Ok(), Is.False);
         }
 
         [Test]
         public void InitShutdownSequence()
         {
             Ros2cs.Init();
+            Assert.That(Ros2cs.Ok(), Is.True);
             Ros2cs.Shutdown();
+            Assert.That(Ros2cs.Ok(), Is.False);
+
             Ros2cs.Init();
+            Assert.That(Ros2cs.Ok(), Is.True);
             Ros2cs.Shutdown();
+            Assert.That(Ros2cs.Ok(), Is.False);
         }
 
         [Test]
@@ -55,15 +69,22 @@ namespace ROS2.Test
         {
             Ros2cs.Init();
             Ros2cs.Init();
+            Assert.That(Ros2cs.Ok(), Is.True);
+
             Ros2cs.Shutdown();
+            Assert.That(Ros2cs.Ok(), Is.False);
         }
 
         [Test]
         public void DoubleShutdown()
         {
             Ros2cs.Init();
+            Assert.That(Ros2cs.Ok(), Is.True);
+
             Ros2cs.Shutdown();
+            Assert.That(Ros2cs.Ok(), Is.False);
             Ros2cs.Shutdown();
+            Assert.That(Ros2cs.Ok(), Is.False);
         }
 
         [Test]

--- a/src/ros2cs/ros2cs_tests/src/LargeMessageTest.cs
+++ b/src/ros2cs/ros2cs_tests/src/LargeMessageTest.cs
@@ -38,8 +38,9 @@ namespace ROS2.Test
         [TearDown]
         public void TearDown()
         {
-            publisher.Dispose();
-            subscriptionNode.Dispose();
+            publisher?.Dispose();
+            publisherNode?.Dispose();
+            subscriptionNode?.Dispose();
             Ros2cs.Shutdown();
         }
 
@@ -50,7 +51,7 @@ namespace ROS2.Test
             subscriptionNode.CreateSubscription<std_msgs.msg.Float64MultiArray>(
                 "subscription_test_topic", (msg) => { callbackTriggered = true; });
 
-            std_msgs.msg.Float64MultiArray largeMsg = new std_msgs.msg.Float64MultiArray();
+            using var largeMsg = new std_msgs.msg.Float64MultiArray();
             largeMsg.Data = new double[1024];
 
             publisher.Publish(largeMsg);

--- a/src/ros2cs/ros2cs_tests/src/LargeMessageTest.cs
+++ b/src/ros2cs/ros2cs_tests/src/LargeMessageTest.cs
@@ -1,5 +1,9 @@
 ﻿// Copyright 2019 Dyno Robotics (by Samuel Lindgren samuel@dynorobotics.se)
 // Copyright 2019-2021 Robotec.ai
+// Modifications Copyright (c) 2026 Jianbin Liu.
+//
+// Modifications by Jianbin Liu:
+// - Audited large-message regression tests after generated type handling updates.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/ros2cs/ros2cs_tests/src/MessagesTest.cs
+++ b/src/ros2cs/ros2cs_tests/src/MessagesTest.cs
@@ -27,13 +27,14 @@ namespace ROS2.Test
         [Test]
         public void CreateMessage()
         {
-            std_msgs.msg.Bool msg = new std_msgs.msg.Bool();
+            using var msg = new std_msgs.msg.Bool();
+            Assert.That(msg.IsDisposed, Is.False);
         }
 
         [Test]
         public void SetBoolData()
         {
-            std_msgs.msg.Bool msg = new std_msgs.msg.Bool();
+            using var msg = new std_msgs.msg.Bool();
             Assert.That(msg.Data, Is.False);
             msg.Data = true;
             Assert.That(msg.Data, Is.True);
@@ -44,7 +45,7 @@ namespace ROS2.Test
         [Test]
         public void SetInt64Data()
         {
-            std_msgs.msg.Int64 msg = new std_msgs.msg.Int64();
+            using var msg = new std_msgs.msg.Int64();
             Assert.That(msg.Data, Is.EqualTo(0));
             msg.Data = 12345;
             Assert.That(msg.Data, Is.EqualTo(12345));
@@ -53,7 +54,7 @@ namespace ROS2.Test
         [Test]
         public void SetStringData()
         {
-            std_msgs.msg.String msg = new std_msgs.msg.String();
+            using var msg = new std_msgs.msg.String();
             Assert.That(msg.Data, Is.EqualTo(""));
             msg.Data = "Show me what you got!";
             Assert.That(msg.Data, Is.EqualTo("Show me what you got!"));
@@ -62,7 +63,7 @@ namespace ROS2.Test
         [Test]
         public void SetDefaults()
         {
-            test_msgs.msg.Defaults msg = new test_msgs.msg.Defaults();
+            using var msg = new test_msgs.msg.Defaults();
             msg.Int32_value = 24;
             Assert.That(msg.Int32_value, Is.EqualTo(24));
             msg.Float32_value = 3.14F;
@@ -72,14 +73,15 @@ namespace ROS2.Test
         [Test]
         public void SetStrings()
         {
-            test_msgs.msg.Strings msg = new test_msgs.msg.Strings();
+            using var msg = new test_msgs.msg.Strings();
             msg.String_value = "Turtles all the way down";
             Assert.That(msg.String_value, Is.EqualTo("Turtles all the way down"));
         }
+
         [Test]
-        public void SetUnboundedSequenses()
+        public void SetUnboundedSequences()
         {
-            test_msgs.msg.UnboundedSequences msg = new test_msgs.msg.UnboundedSequences();
+            using var msg = new test_msgs.msg.UnboundedSequences();
             bool[] setBoolSequence = new bool[2];
             setBoolSequence[0] = true;
             setBoolSequence[1] = false;
@@ -93,7 +95,7 @@ namespace ROS2.Test
             int[] setIntSequence = new int[2];
             setIntSequence[0] = 123;
             setIntSequence[1] = 456;
-            test_msgs.msg.UnboundedSequences msg2 = new test_msgs.msg.UnboundedSequences();
+            using var msg2 = new test_msgs.msg.UnboundedSequences();
             msg2.Int32_values = setIntSequence;
             int[] getIntList = msg2.Int32_values;
             Assert.That(getIntList.Length, Is.EqualTo(2));
@@ -103,7 +105,7 @@ namespace ROS2.Test
             string[] setStringSequence = new string[2];
             setStringSequence[0] = "Hello";
             setStringSequence[1] = "world";
-            test_msgs.msg.UnboundedSequences msg3 = new test_msgs.msg.UnboundedSequences();
+            using var msg3 = new test_msgs.msg.UnboundedSequences();
             msg3.String_values = setStringSequence;
             string[] getStringSequence = msg3.String_values;
             Assert.That(getStringSequence.Length, Is.EqualTo(2));
@@ -116,7 +118,7 @@ namespace ROS2.Test
         public void NativeRoundtripPreservesInt8Sequence()
         {
             sbyte[] expected = new sbyte[] { -128, -1, 0, 1, 127 };
-            test_msgs.msg.UnboundedSequences msg = new test_msgs.msg.UnboundedSequences();
+            using var msg = new test_msgs.msg.UnboundedSequences();
             msg.Int8_values = expected;
 
             msg.WriteNativeMessage();
@@ -127,9 +129,9 @@ namespace ROS2.Test
         }
 
         [Test]
-        public void SetBoundedSequenses()
+        public void SetBoundedSequences()
         {
-            test_msgs.msg.BoundedSequences msg = new test_msgs.msg.BoundedSequences();
+            using var msg = new test_msgs.msg.BoundedSequences();
             bool[] setBoolSequence = new bool[2];
             setBoolSequence[0] = true;
             setBoolSequence[1] = false;
@@ -143,7 +145,7 @@ namespace ROS2.Test
             int[] setIntSequence = new int[2];
             setIntSequence[0] = 123;
             setIntSequence[1] = 456;
-            test_msgs.msg.BoundedSequences msg2 = new test_msgs.msg.BoundedSequences();
+            using var msg2 = new test_msgs.msg.BoundedSequences();
             msg2.Int32_values = setIntSequence;
             int[] getIntList = msg2.Int32_values;
             Assert.That(getIntList.Length, Is.EqualTo(2));
@@ -153,7 +155,7 @@ namespace ROS2.Test
             string[] setStringSequence = new string[2];
             setStringSequence[0] = "Hello";
             setStringSequence[1] = "world";
-            test_msgs.msg.BoundedSequences msg3 = new test_msgs.msg.BoundedSequences();
+            using var msg3 = new test_msgs.msg.BoundedSequences();
             msg3.String_values = setStringSequence;
             string[] getStringSequence = msg3.String_values;
             Assert.That(getStringSequence.Length, Is.EqualTo(2));
@@ -164,7 +166,7 @@ namespace ROS2.Test
         [Test]
         public void SetNested()
         {
-            test_msgs.msg.Nested msg = new test_msgs.msg.Nested();
+            using var msg = new test_msgs.msg.Nested();
             test_msgs.msg.BasicTypes basic_types_msg = msg.Basic_types_value;
             Assert.That(basic_types_msg.Int32_value, Is.EqualTo(0));
             basic_types_msg.Int32_value = 25;
@@ -176,10 +178,10 @@ namespace ROS2.Test
         [Test]
         public void SetMultiNested()
         {
-            test_msgs.msg.MultiNested msg = new test_msgs.msg.MultiNested();
+            using var msg = new test_msgs.msg.MultiNested();
 
             msg.Unbounded_sequence_of_unbounded_sequences = new test_msgs.msg.UnboundedSequences[3];
-            var setUnboundedSequences = new test_msgs.msg.UnboundedSequences();
+            using var setUnboundedSequences = new test_msgs.msg.UnboundedSequences();
             string[] string_array = new string[2];
             setUnboundedSequences.String_values = string_array;
             setUnboundedSequences.String_values[0] = "hello";

--- a/src/ros2cs/ros2cs_tests/src/MessagesTest.cs
+++ b/src/ros2cs/ros2cs_tests/src/MessagesTest.cs
@@ -17,7 +17,10 @@
 // Modifications by Jianbin Liu:
 // - Added native roundtrip coverage for int8 sequences.
 // - Added generated message finalizer policy coverage.
+// - Expanded finalizer policy coverage across loaded generated message types.
 
+using System;
+using System.Linq;
 using System.Reflection;
 using NUnit.Framework;
 
@@ -66,11 +69,46 @@ namespace ROS2.Test
         [Test]
         public void GeneratedMessagesDoNotDeclareFinalizer()
         {
-            var finalizeMethod = typeof(std_msgs.msg.String).GetMethod(
-                "Finalize",
-                BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
+            Type[] anchorTypes =
+            {
+                typeof(std_msgs.msg.String),
+                typeof(std_msgs.msg.Bool),
+                typeof(test_msgs.msg.UnboundedSequences),
+                typeof(example_interfaces.srv.AddTwoInts_Request),
+                typeof(example_interfaces.srv.AddTwoInts_Response)
+            };
 
-            Assert.That(finalizeMethod, Is.Null);
+            Assert.That(anchorTypes, Is.Not.Empty);
+
+            var messageTypes = AppDomain.CurrentDomain.GetAssemblies()
+                .SelectMany(assembly =>
+                {
+                    try
+                    {
+                        return assembly.GetTypes();
+                    }
+                    catch (ReflectionTypeLoadException e)
+                    {
+                        return e.Types.Where(type => type != null);
+                    }
+                })
+                .Where(type => type != null)
+                .Where(type => typeof(Message).IsAssignableFrom(type))
+                .Where(type => !type.IsAbstract)
+                .Where(type => type.Namespace != null &&
+                    (type.Namespace.EndsWith(".msg") || type.Namespace.EndsWith(".srv")))
+                .ToArray();
+
+            Assert.That(messageTypes, Is.Not.Empty);
+
+            foreach (Type messageType in messageTypes)
+            {
+                var finalizeMethod = messageType.GetMethod(
+                    "Finalize",
+                    BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
+
+                Assert.That(finalizeMethod, Is.Null, messageType.FullName + " declares a finalizer.");
+            }
         }
 
         [Test]

--- a/src/ros2cs/ros2cs_tests/src/MessagesTest.cs
+++ b/src/ros2cs/ros2cs_tests/src/MessagesTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright 2019 Dyno Robotics (by Samuel Lindgren samuel@dynorobotics.se)
 // Copyright 2019-2021 Robotec.ai
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +13,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// Modifications by Jianbin Liu:
+// - Added native roundtrip coverage for int8 sequences.
 
 using NUnit.Framework;
 
@@ -105,6 +109,21 @@ namespace ROS2.Test
             Assert.That(getStringSequence.Length, Is.EqualTo(2));
             Assert.That(getStringSequence[0], Is.EqualTo("Hello"));
             Assert.That(getStringSequence[1], Is.EqualTo("world"));
+        }
+
+        /// <summary>Verifies generated int8 sequence marshaling preserves signed values through native storage.</summary>
+        [Test]
+        public void NativeRoundtripPreservesInt8Sequence()
+        {
+            sbyte[] expected = new sbyte[] { -128, -1, 0, 1, 127 };
+            test_msgs.msg.UnboundedSequences msg = new test_msgs.msg.UnboundedSequences();
+            msg.Int8_values = expected;
+
+            msg.WriteNativeMessage();
+            msg.Int8_values = new sbyte[0];
+            msg.ReadNativeMessage();
+
+            Assert.That(msg.Int8_values, Is.EqualTo(expected));
         }
 
         [Test]

--- a/src/ros2cs/ros2cs_tests/src/MessagesTest.cs
+++ b/src/ros2cs/ros2cs_tests/src/MessagesTest.cs
@@ -16,7 +16,9 @@
 
 // Modifications by Jianbin Liu:
 // - Added native roundtrip coverage for int8 sequences.
+// - Added generated message finalizer policy coverage.
 
+using System.Reflection;
 using NUnit.Framework;
 
 namespace ROS2.Test
@@ -58,6 +60,17 @@ namespace ROS2.Test
             Assert.That(msg.Data, Is.EqualTo(""));
             msg.Data = "Show me what you got!";
             Assert.That(msg.Data, Is.EqualTo("Show me what you got!"));
+        }
+
+        /// <summary>Generated messages must not call native destroy functions from finalizers.</summary>
+        [Test]
+        public void GeneratedMessagesDoNotDeclareFinalizer()
+        {
+            var finalizeMethod = typeof(std_msgs.msg.String).GetMethod(
+                "Finalize",
+                BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
+
+            Assert.That(finalizeMethod, Is.Null);
         }
 
         [Test]

--- a/src/ros2cs/ros2cs_tests/src/NativeMethodsTest.cs
+++ b/src/ros2cs/ros2cs_tests/src/NativeMethodsTest.cs
@@ -17,6 +17,8 @@
 // Modifications by Jianbin Liu:
 // - Fixed native test helper option ownership so allocated options are released by teardown.
 // - Added missing native subscription cleanup in the subscription fixture.
+// - Fixed native publisher allocation parameter and wait-set cleanup in native tests.
+// - Added fail-fast native return checks and guarded cleanup in QoS native tests.
 
 using NUnit.Framework;
 using System;
@@ -352,9 +354,8 @@ namespace ROS2.TestNativeMethods
             IntPtr publisherOptions = new IntPtr();
             PublisherInitialize.InitPublisher(ref publisher, ref node, ref publisherOptions);
             using var msg = new std_msgs.msg.Bool();
-            rcl_allocator_t allocator = NativeRcl.rcutils_get_default_allocator();
 
-            var ret = (RCLReturnEnum)NativeRcl.rcl_publish(ref publisher, msg.Handle, allocator.allocate);
+            var ret = (RCLReturnEnum)NativeRcl.rcl_publish(ref publisher, msg.Handle, IntPtr.Zero);
             Assert.That(ret, Is.EqualTo(RCLReturnEnum.RCL_RET_OK), Utils.PopRclErrorString());
             PublisherInitialize.ShutdownPublisher(ref publisher, ref node, publisherOptions);
         }
@@ -467,27 +468,39 @@ namespace ROS2.TestNativeMethods
 
             rcl_allocator_t allocator = NativeRcl.rcutils_get_default_allocator();
             rcl_wait_set_t waitSet = NativeRcl.rcl_get_zero_initialized_wait_set();
-            TestUtils.AssertRetOk(NativeRcl.rcl_wait_set_init(
-                ref waitSet,
-                (UIntPtr)1,
-                (UIntPtr)0,
-                (UIntPtr)0,
-                (UIntPtr)0,
-                (UIntPtr)0,
-                (UIntPtr)0,
-                ref context,
-                allocator
-            ));
-            TestUtils.AssertRetOk(NativeRcl.rcl_wait_set_clear(ref waitSet));
+            bool waitSetInitialized = false;
+            try
+            {
+                TestUtils.AssertRetOk(NativeRcl.rcl_wait_set_init(
+                    ref waitSet,
+                    (UIntPtr)1,
+                    (UIntPtr)0,
+                    (UIntPtr)0,
+                    (UIntPtr)0,
+                    (UIntPtr)0,
+                    (UIntPtr)0,
+                    ref context,
+                    allocator
+                ));
+                waitSetInitialized = true;
+                TestUtils.AssertRetOk(NativeRcl.rcl_wait_set_clear(ref waitSet));
 
-            Assert.That(NativeRcl.rcl_subscription_is_valid(ref subscription), Is.True);
-            UIntPtr index = (UIntPtr)42;
-            TestUtils.AssertRetOk(NativeRcl.rcl_wait_set_add_subscription(ref waitSet, ref subscription, ref index));
-            Assert.That(index.ToUInt64(), Is.EqualTo(0));
+                Assert.That(NativeRcl.rcl_subscription_is_valid(ref subscription), Is.True);
+                UIntPtr index = (UIntPtr)42;
+                TestUtils.AssertRetOk(NativeRcl.rcl_wait_set_add_subscription(ref waitSet, ref subscription, ref index));
+                Assert.That(index.ToUInt64(), Is.EqualTo(0));
 
-            long timeout_ns = 10*1000*1000;
-            var ret = (RCLReturnEnum)NativeRcl.rcl_wait(ref waitSet, timeout_ns);
-            Assert.That(ret, Is.EqualTo(RCLReturnEnum.RCL_RET_TIMEOUT));
+                long timeout_ns = 10*1000*1000;
+                var ret = (RCLReturnEnum)NativeRcl.rcl_wait(ref waitSet, timeout_ns);
+                Assert.That(ret, Is.EqualTo(RCLReturnEnum.RCL_RET_TIMEOUT));
+            }
+            finally
+            {
+                if (waitSetInitialized)
+                {
+                    TestUtils.AssertRetOk(NativeRcl.rcl_wait_set_fini(ref waitSet));
+                }
+            }
         }
     }
 
@@ -545,19 +558,30 @@ namespace ROS2.TestNativeMethods
         {
             rcl_allocator_t allocator = NativeRcl.rcutils_get_default_allocator();
             rcl_wait_set_t waitSet = NativeRcl.rcl_get_zero_initialized_wait_set();
-            NativeRcl.rcl_wait_set_init(
-                ref waitSet,
-                (UIntPtr)1,
-                (UIntPtr)0,
-                (UIntPtr)0,
-                (UIntPtr)0,
-                (UIntPtr)0,
-                (UIntPtr)0,
-                ref context,
-                allocator
-            );
-            TestUtils.AssertRetOk(NativeRcl.rcl_wait_set_clear(ref waitSet));
-            TestUtils.AssertRetOk(NativeRcl.rcl_wait_set_fini(ref waitSet));
+            bool waitSetInitialized = false;
+            try
+            {
+                TestUtils.AssertRetOk(NativeRcl.rcl_wait_set_init(
+                    ref waitSet,
+                    (UIntPtr)1,
+                    (UIntPtr)0,
+                    (UIntPtr)0,
+                    (UIntPtr)0,
+                    (UIntPtr)0,
+                    (UIntPtr)0,
+                    ref context,
+                    allocator
+                ));
+                waitSetInitialized = true;
+                TestUtils.AssertRetOk(NativeRcl.rcl_wait_set_clear(ref waitSet));
+            }
+            finally
+            {
+                if (waitSetInitialized)
+                {
+                    TestUtils.AssertRetOk(NativeRcl.rcl_wait_set_fini(ref waitSet));
+                }
+            }
         }
     }
 
@@ -591,17 +615,26 @@ namespace ROS2.TestNativeMethods
             {
                 IntPtr subscriptionOptions = NativeRclInterface.rclcs_subscription_create_options(qos.handle);
                 Assert.That(subscriptionOptions, Is.Not.EqualTo(IntPtr.Zero));
+                bool subscriptionInitialized = false;
+                try
+                {
+                    using var msg = new std_msgs.msg.Bool();
+                    MessageInternals msgInternals = msg;
+                    IntPtr typeSupportHandle = msgInternals.TypeSupportHandle;
+                    TestUtils.AssertRetOk(NativeRcl.rcl_subscription_init(
+                        ref subscription, ref node, typeSupportHandle, "/subscriber_test_topic", subscriptionOptions));
+                    subscriptionInitialized = true;
 
-                using var msg = new std_msgs.msg.Bool();
-                MessageInternals msgInternals = msg;
-                IntPtr typeSupportHandle = msgInternals.TypeSupportHandle;
-                NativeRcl.rcl_subscription_init(
-                    ref subscription, ref node, typeSupportHandle, "/subscriber_test_topic", subscriptionOptions);
-
-                Assert.That(NativeRcl.rcl_subscription_is_valid(ref subscription), Is.True);
-
-                NativeRcl.rcl_subscription_fini(ref subscription, ref node);
-                NativeRclInterface.rclcs_subscription_dispose_options(subscriptionOptions);
+                    Assert.That(NativeRcl.rcl_subscription_is_valid(ref subscription), Is.True);
+                }
+                finally
+                {
+                    if (subscriptionInitialized)
+                    {
+                        TestUtils.AssertRetOk(NativeRcl.rcl_subscription_fini(ref subscription, ref node));
+                    }
+                    NativeRclInterface.rclcs_subscription_dispose_options(subscriptionOptions);
+                }
             }
         }
     }

--- a/src/ros2cs/ros2cs_tests/src/NativeMethodsTest.cs
+++ b/src/ros2cs/ros2cs_tests/src/NativeMethodsTest.cs
@@ -234,14 +234,14 @@ namespace ROS2.TestNativeMethods
         }
 
         [Test]
-        public void NodeGetNamespace()
+        public void NodeGetName()
         {
             string nodeNameFromRcl = Utils.PtrToString(NativeRcl.rcl_node_get_name(ref node));
             Assert.That("node_test", Is.EqualTo(nodeNameFromRcl));
         }
 
         [Test]
-        public void NodeGetName()
+        public void NodeGetNamespace()
         {
             string nodeNamespaceFromRcl = Utils.PtrToString(NativeRcl.rcl_node_get_namespace(ref node));
             Assert.That("/ns", Is.EqualTo(nodeNamespaceFromRcl));
@@ -295,8 +295,9 @@ namespace ROS2.TestNativeMethods
                 publisherOptions = NativeRclInterface.rclcs_publisher_create_options(qos.handle);
             }
             Assert.That(publisherOptions, Is.Not.EqualTo(IntPtr.Zero));
-            MessageInternals msg = new std_msgs.msg.Bool();
-            IntPtr typeSupportHandle = msg.TypeSupportHandle;
+            using var msg = new std_msgs.msg.Bool();
+            MessageInternals msgInternals = msg;
+            IntPtr typeSupportHandle = msgInternals.TypeSupportHandle;
             var ret = (RCLReturnEnum)NativeRcl.rcl_publisher_init(
                 ref publisher, ref node, typeSupportHandle, "publisher_test_topic", publisherOptions);
             Assert.That(ret, Is.EqualTo(RCLReturnEnum.RCL_RET_OK), Utils.PopRclErrorString());
@@ -350,7 +351,7 @@ namespace ROS2.TestNativeMethods
             rcl_publisher_t publisher = new rcl_publisher_t();
             IntPtr publisherOptions = new IntPtr();
             PublisherInitialize.InitPublisher(ref publisher, ref node, ref publisherOptions);
-            MessageInternals msg = new std_msgs.msg.Bool();
+            using var msg = new std_msgs.msg.Bool();
             rcl_allocator_t allocator = NativeRcl.rcutils_get_default_allocator();
 
             var ret = (RCLReturnEnum)NativeRcl.rcl_publish(ref publisher, msg.Handle, allocator.allocate);
@@ -388,8 +389,9 @@ namespace ROS2.TestNativeMethods
                 subscriptionOptions = NativeRclInterface.rclcs_subscription_create_options(qos.handle);
             }
             Assert.That(subscriptionOptions, Is.Not.EqualTo(IntPtr.Zero));
-            MessageInternals msg = new std_msgs.msg.Bool();
-            IntPtr typeSupportHandle = msg.TypeSupportHandle;
+            using var msg = new std_msgs.msg.Bool();
+            MessageInternals msgInternals = msg;
+            IntPtr typeSupportHandle = msgInternals.TypeSupportHandle;
             var ret = (RCLReturnEnum)NativeRcl.rcl_subscription_init(
                 ref subscription, ref node, typeSupportHandle, "/subscriber_test_topic", subscriptionOptions);
             Assert.That(ret, Is.EqualTo(RCLReturnEnum.RCL_RET_OK), Utils.PopRclErrorString());
@@ -590,8 +592,9 @@ namespace ROS2.TestNativeMethods
                 IntPtr subscriptionOptions = NativeRclInterface.rclcs_subscription_create_options(qos.handle);
                 Assert.That(subscriptionOptions, Is.Not.EqualTo(IntPtr.Zero));
 
-                MessageInternals msg = new std_msgs.msg.Bool();
-                IntPtr typeSupportHandle = msg.TypeSupportHandle;
+                using var msg = new std_msgs.msg.Bool();
+                MessageInternals msgInternals = msg;
+                IntPtr typeSupportHandle = msgInternals.TypeSupportHandle;
                 NativeRcl.rcl_subscription_init(
                     ref subscription, ref node, typeSupportHandle, "/subscriber_test_topic", subscriptionOptions);
 

--- a/src/ros2cs/ros2cs_tests/src/NativeMethodsTest.cs
+++ b/src/ros2cs/ros2cs_tests/src/NativeMethodsTest.cs
@@ -19,6 +19,7 @@
 // - Added missing native subscription cleanup in the subscription fixture.
 // - Fixed native publisher allocation parameter and wait-set cleanup in native tests.
 // - Added fail-fast native return checks and guarded cleanup in QoS native tests.
+// - Asserted native option-dispose return codes for wrappers that expose rcl fini.
 
 using NUnit.Framework;
 using System;
@@ -177,7 +178,13 @@ namespace ROS2.TestNativeMethods
         {
             IntPtr defaultNodeOptions = NativeRclInterface.rclcs_node_create_default_options();
             Assert.That(defaultNodeOptions, Is.Not.EqualTo(IntPtr.Zero));
-            NativeRclInterface.rclcs_node_dispose_options(defaultNodeOptions);
+            TestUtils.AssertRetOk(NativeRclInterface.rclcs_node_dispose_options(defaultNodeOptions));
+        }
+
+        [Test]
+        public void NodeDisposeOptionsAcceptsNull()
+        {
+            TestUtils.AssertRetOk(NativeRclInterface.rclcs_node_dispose_options(IntPtr.Zero));
         }
 
         public static void InitNode(ref rcl_node_t node, ref IntPtr nodeOptions, ref rcl_context_t context)
@@ -199,7 +206,7 @@ namespace ROS2.TestNativeMethods
             NativeRcl.rcl_node_fini(ref node);
             if (nodeOptions != IntPtr.Zero)
             {
-                NativeRclInterface.rclcs_node_dispose_options(nodeOptions);
+                TestUtils.AssertRetOk(NativeRclInterface.rclcs_node_dispose_options(nodeOptions));
             }
         }
 
@@ -377,8 +384,14 @@ namespace ROS2.TestNativeMethods
             {
                 IntPtr subscriptionOptions = NativeRclInterface.rclcs_subscription_create_options(qos.handle);
                 Assert.That(subscriptionOptions, Is.Not.EqualTo(IntPtr.Zero));
-                NativeRclInterface.rclcs_subscription_dispose_options(subscriptionOptions);
+                TestUtils.AssertRetOk(NativeRclInterface.rclcs_subscription_dispose_options(subscriptionOptions));
             }
+        }
+
+        [Test]
+        public void SubscriptionDisposeOptionsAcceptsNull()
+        {
+            TestUtils.AssertRetOk(NativeRclInterface.rclcs_subscription_dispose_options(IntPtr.Zero));
         }
 
         public static void InitSubscription(
@@ -404,7 +417,7 @@ namespace ROS2.TestNativeMethods
             var ret = (RCLReturnEnum)NativeRcl.rcl_subscription_fini(ref subscription, ref node);
             if (subscriptionOptions != IntPtr.Zero)
             {
-                NativeRclInterface.rclcs_subscription_dispose_options(subscriptionOptions);
+                TestUtils.AssertRetOk(NativeRclInterface.rclcs_subscription_dispose_options(subscriptionOptions));
             }
             Assert.That(ret, Is.EqualTo(RCLReturnEnum.RCL_RET_OK), Utils.PopRclErrorString());
         }
@@ -633,7 +646,7 @@ namespace ROS2.TestNativeMethods
                     {
                         TestUtils.AssertRetOk(NativeRcl.rcl_subscription_fini(ref subscription, ref node));
                     }
-                    NativeRclInterface.rclcs_subscription_dispose_options(subscriptionOptions);
+                    TestUtils.AssertRetOk(NativeRclInterface.rclcs_subscription_dispose_options(subscriptionOptions));
                 }
             }
         }

--- a/src/ros2cs/ros2cs_tests/src/NativeMetodsTest.cs
+++ b/src/ros2cs/ros2cs_tests/src/NativeMetodsTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright 2019 Dyno Robotics (by Samuel Lindgren samuel@dynorobotics.se)
 // Copyright 2019-2021 Robotec.ai
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +13,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// Modifications by Jianbin Liu:
+// - Fixed native test helper option ownership so allocated options are released by teardown.
+// - Added missing native subscription cleanup in the subscription fixture.
 
 using NUnit.Framework;
 using System;
@@ -34,6 +39,8 @@ namespace ROS2.TestNativeMethods
             context = NativeRcl.rcl_get_zero_initialized_context();
 
             ret = (RCLReturnEnum)NativeRcl.rcl_init(0, null, ref init_options, ref context);
+            Assert.That(ret, Is.EqualTo(RCLReturnEnum.RCL_RET_OK), Utils.PopRclErrorString());
+            ret = (RCLReturnEnum)NativeRcl.rcl_init_options_fini(ref init_options);
             Assert.That(ret, Is.EqualTo(RCLReturnEnum.RCL_RET_OK), Utils.PopRclErrorString());
             Assert.That(NativeRcl.rcl_context_is_valid(ref context), Is.True);
         }
@@ -98,6 +105,8 @@ namespace ROS2.TestNativeMethods
             rcl_allocator_t allocator = NativeRcl.rcutils_get_default_allocator();
             int ret = NativeRcl.rcl_init_options_init(ref init_options, allocator);
             Assert.That((RCLReturnEnum)ret, Is.EqualTo(RCLReturnEnum.RCL_RET_OK));
+            ret = NativeRcl.rcl_init_options_fini(ref init_options);
+            Assert.That((RCLReturnEnum)ret, Is.EqualTo(RCLReturnEnum.RCL_RET_OK));
         }
 
         [Test]
@@ -119,7 +128,8 @@ namespace ROS2.TestNativeMethods
         {
             rcl_init_options_t init_options = NativeRcl.rcl_get_zero_initialized_init_options();
             rcl_allocator_t allocator = NativeRcl.rcutils_get_default_allocator();
-            NativeRcl.rcl_init_options_init(ref init_options, allocator);
+            int initRet = NativeRcl.rcl_init_options_init(ref init_options, allocator);
+            Assert.That((RCLReturnEnum)initRet, Is.EqualTo(RCLReturnEnum.RCL_RET_OK));
             rcl_context_t context = NativeRcl.rcl_get_zero_initialized_context();
 
             var ret = (RCLReturnEnum)NativeRcl.rcl_init(
@@ -129,6 +139,8 @@ namespace ROS2.TestNativeMethods
             Assert.That(NativeRcl.rcl_context_is_valid(ref context), Is.True);
             ret = (RCLReturnEnum)NativeRcl.rcl_shutdown(ref context);
             Assert.That(ret, Is.EqualTo(RCLReturnEnum.RCL_RET_OK));
+            ret = (RCLReturnEnum)NativeRcl.rcl_init_options_fini(ref init_options);
+            Assert.That(ret, Is.EqualTo(RCLReturnEnum.RCL_RET_OK), Utils.PopRclErrorString());
 
             ret = (RCLReturnEnum)NativeRcl.rcl_context_fini(ref context);
             Assert.That(ret, Is.EqualTo(RCLReturnEnum.RCL_RET_OK));
@@ -162,14 +174,16 @@ namespace ROS2.TestNativeMethods
         public void NodeGetDefaultOptions()
         {
             IntPtr defaultNodeOptions = NativeRclInterface.rclcs_node_create_default_options();
+            Assert.That(defaultNodeOptions, Is.Not.EqualTo(IntPtr.Zero));
             NativeRclInterface.rclcs_node_dispose_options(defaultNodeOptions);
         }
 
-        public static void InitNode(ref rcl_node_t node, IntPtr nodeOptions, ref rcl_context_t context)
+        public static void InitNode(ref rcl_node_t node, ref IntPtr nodeOptions, ref rcl_context_t context)
         {
             node = NativeRcl.rcl_get_zero_initialized_node();
 
             nodeOptions = NativeRclInterface.rclcs_node_create_default_options();
+            Assert.That(nodeOptions, Is.Not.EqualTo(IntPtr.Zero));
             string name = "node_test";
             string nodeNamespace = "/ns";
 
@@ -181,7 +195,10 @@ namespace ROS2.TestNativeMethods
         public static void ShutdownNode(ref rcl_node_t node, IntPtr nodeOptions)
         {
             NativeRcl.rcl_node_fini(ref node);
-            NativeRclInterface.rclcs_node_dispose_options(nodeOptions);
+            if (nodeOptions != IntPtr.Zero)
+            {
+                NativeRclInterface.rclcs_node_dispose_options(nodeOptions);
+            }
         }
 
         [Test]
@@ -190,7 +207,7 @@ namespace ROS2.TestNativeMethods
             rcl_node_t node = new rcl_node_t();
             IntPtr nodeOptions = new IntPtr();
 
-            InitNode(ref node, nodeOptions, ref context);
+            InitNode(ref node, ref nodeOptions, ref context);
             ShutdownNode(ref node, nodeOptions);
         }
     }
@@ -206,7 +223,7 @@ namespace ROS2.TestNativeMethods
         public void SetUp()
         {
             RCLInitialize.InitRcl(ref context);
-            NodeInitialize.InitNode(ref node, nodeOptions, ref context);
+            NodeInitialize.InitNode(ref node, ref nodeOptions, ref context);
         }
 
         [TearDown]
@@ -242,7 +259,7 @@ namespace ROS2.TestNativeMethods
         public void SetUp()
         {
             RCLInitialize.InitRcl(ref context);
-            NodeInitialize.InitNode(ref node, nodeOptions, ref context);
+            NodeInitialize.InitNode(ref node, ref nodeOptions, ref context);
         }
 
         [TearDown]
@@ -255,8 +272,12 @@ namespace ROS2.TestNativeMethods
         [Test]
         public void PublisherCreateOptions()
         {
-            QualityOfServiceProfile qos = new QualityOfServiceProfile();
-            IntPtr publisherOptions = NativeRclInterface.rclcs_publisher_create_options(qos.handle);
+            using (QualityOfServiceProfile qos = new QualityOfServiceProfile())
+            {
+                IntPtr publisherOptions = NativeRclInterface.rclcs_publisher_create_options(qos.handle);
+                Assert.That(publisherOptions, Is.Not.EqualTo(IntPtr.Zero));
+                NativeRclInterface.rclcs_publisher_dispose_options(publisherOptions);
+            }
         }
 
         [Test]
@@ -266,15 +287,19 @@ namespace ROS2.TestNativeMethods
         }
 
         public static void InitPublisher(
-            ref rcl_publisher_t publisher, ref rcl_node_t node, IntPtr publisherOptions)
+            ref rcl_publisher_t publisher, ref rcl_node_t node, ref IntPtr publisherOptions)
         {
             publisher = NativeRcl.rcl_get_zero_initialized_publisher();
-            QualityOfServiceProfile qos = new QualityOfServiceProfile();
-            publisherOptions = NativeRclInterface.rclcs_publisher_create_options(qos.handle);
+            using (QualityOfServiceProfile qos = new QualityOfServiceProfile())
+            {
+                publisherOptions = NativeRclInterface.rclcs_publisher_create_options(qos.handle);
+            }
+            Assert.That(publisherOptions, Is.Not.EqualTo(IntPtr.Zero));
             MessageInternals msg = new std_msgs.msg.Bool();
             IntPtr typeSupportHandle = msg.TypeSupportHandle;
             var ret = (RCLReturnEnum)NativeRcl.rcl_publisher_init(
                 ref publisher, ref node, typeSupportHandle, "publisher_test_topic", publisherOptions);
+            Assert.That(ret, Is.EqualTo(RCLReturnEnum.RCL_RET_OK), Utils.PopRclErrorString());
         }
 
         public static void ShutdownPublisher(
@@ -282,7 +307,10 @@ namespace ROS2.TestNativeMethods
         {
             var ret = (RCLReturnEnum)NativeRcl.rcl_publisher_fini(ref publisher, ref node);
             Assert.That(ret, Is.EqualTo(RCLReturnEnum.RCL_RET_OK), Utils.PopRclErrorString());
-            NativeRclInterface.rclcs_publisher_dispose_options(publisherOptions);
+            if (publisherOptions != IntPtr.Zero)
+            {
+                NativeRclInterface.rclcs_publisher_dispose_options(publisherOptions);
+            }
         }
 
         [Test]
@@ -290,7 +318,7 @@ namespace ROS2.TestNativeMethods
         {
             rcl_publisher_t publisher = new rcl_publisher_t();
             IntPtr publisherOptions = new IntPtr();
-            InitPublisher(ref publisher, ref node, publisherOptions);
+            InitPublisher(ref publisher, ref node, ref publisherOptions);
             ShutdownPublisher(ref publisher, ref node, publisherOptions);
         }
     }
@@ -306,7 +334,7 @@ namespace ROS2.TestNativeMethods
         public void SetUp()
         {
             RCLInitialize.InitRcl(ref context);
-            NodeInitialize.InitNode(ref node, nodeOptions, ref context);
+            NodeInitialize.InitNode(ref node, ref nodeOptions, ref context);
         }
 
         [TearDown]
@@ -321,7 +349,7 @@ namespace ROS2.TestNativeMethods
         {
             rcl_publisher_t publisher = new rcl_publisher_t();
             IntPtr publisherOptions = new IntPtr();
-            PublisherInitialize.InitPublisher(ref publisher, ref node, publisherOptions);
+            PublisherInitialize.InitPublisher(ref publisher, ref node, ref publisherOptions);
             MessageInternals msg = new std_msgs.msg.Bool();
             rcl_allocator_t allocator = NativeRcl.rcutils_get_default_allocator();
 
@@ -343,17 +371,23 @@ namespace ROS2.TestNativeMethods
         [Test]
         public void SubscriptionCreateOptions()
         {
-            QualityOfServiceProfile qos = new QualityOfServiceProfile();
-            IntPtr subscriptionOptions = NativeRclInterface.rclcs_subscription_create_options(qos.handle);
-            NativeRclInterface.rclcs_subscription_dispose_options(subscriptionOptions);
+            using (QualityOfServiceProfile qos = new QualityOfServiceProfile())
+            {
+                IntPtr subscriptionOptions = NativeRclInterface.rclcs_subscription_create_options(qos.handle);
+                Assert.That(subscriptionOptions, Is.Not.EqualTo(IntPtr.Zero));
+                NativeRclInterface.rclcs_subscription_dispose_options(subscriptionOptions);
+            }
         }
 
         public static void InitSubscription(
-            ref rcl_subscription_t subscription, IntPtr subscriptionOptions, ref rcl_node_t node)
+            ref rcl_subscription_t subscription, ref IntPtr subscriptionOptions, ref rcl_node_t node)
         {
             subscription = NativeRcl.rcl_get_zero_initialized_subscription();
-            QualityOfServiceProfile qos = new QualityOfServiceProfile();
-            subscriptionOptions = NativeRclInterface.rclcs_subscription_create_options(qos.handle);            
+            using (QualityOfServiceProfile qos = new QualityOfServiceProfile())
+            {
+                subscriptionOptions = NativeRclInterface.rclcs_subscription_create_options(qos.handle);
+            }
+            Assert.That(subscriptionOptions, Is.Not.EqualTo(IntPtr.Zero));
             MessageInternals msg = new std_msgs.msg.Bool();
             IntPtr typeSupportHandle = msg.TypeSupportHandle;
             var ret = (RCLReturnEnum)NativeRcl.rcl_subscription_init(
@@ -365,7 +399,10 @@ namespace ROS2.TestNativeMethods
             ref rcl_subscription_t subscription, IntPtr subscriptionOptions, ref rcl_node_t node)
         {
             var ret = (RCLReturnEnum)NativeRcl.rcl_subscription_fini(ref subscription, ref node);
-            NativeRclInterface.rclcs_subscription_dispose_options(subscriptionOptions);
+            if (subscriptionOptions != IntPtr.Zero)
+            {
+                NativeRclInterface.rclcs_subscription_dispose_options(subscriptionOptions);
+            }
             Assert.That(ret, Is.EqualTo(RCLReturnEnum.RCL_RET_OK), Utils.PopRclErrorString());
         }
 
@@ -377,12 +414,12 @@ namespace ROS2.TestNativeMethods
             IntPtr nodeOptions = new IntPtr();
 
             RCLInitialize.InitRcl(ref context);
-            NodeInitialize.InitNode(ref node, nodeOptions, ref context);
+            NodeInitialize.InitNode(ref node, ref nodeOptions, ref context);
 
             rcl_subscription_t subscription = new rcl_subscription_t();
             IntPtr subscriptionOptions = new IntPtr();
 
-            InitSubscription(ref subscription, subscriptionOptions, ref node);
+            InitSubscription(ref subscription, ref subscriptionOptions, ref node);
             ShutdownSubscription(ref subscription, subscriptionOptions, ref node);
 
             NodeInitialize.ShutdownNode(ref node, nodeOptions);
@@ -403,13 +440,14 @@ namespace ROS2.TestNativeMethods
         public void SetUp()
         {
             RCLInitialize.InitRcl(ref context);
-            NodeInitialize.InitNode(ref node, nodeOptions, ref context);
-            SubscriptionInitialize.InitSubscription(ref subscription, subscriptionOptions, ref node);
+            NodeInitialize.InitNode(ref node, ref nodeOptions, ref context);
+            SubscriptionInitialize.InitSubscription(ref subscription, ref subscriptionOptions, ref node);
         }
 
         [TearDown]
         public void TearDown()
         {
+            SubscriptionInitialize.ShutdownSubscription(ref subscription, subscriptionOptions, ref node);
             NodeInitialize.ShutdownNode(ref node, nodeOptions);
             RCLInitialize.ShutdownRcl(ref context);
         }
@@ -462,7 +500,7 @@ namespace ROS2.TestNativeMethods
         public void SetUp()
         {
             RCLInitialize.InitRcl(ref context);
-            NodeInitialize.InitNode(ref node, nodeOptions, ref context);
+            NodeInitialize.InitNode(ref node, ref nodeOptions, ref context);
         }
 
         [TearDown]
@@ -532,7 +570,7 @@ namespace ROS2.TestNativeMethods
         public void SetUp()
         {
             RCLInitialize.InitRcl(ref context);
-            NodeInitialize.InitNode(ref node, nodeOptions, ref context);
+            NodeInitialize.InitNode(ref node, ref nodeOptions, ref context);
         }
 
         [TearDown]
@@ -547,18 +585,21 @@ namespace ROS2.TestNativeMethods
         {
             rcl_subscription_t subscription = NativeRcl.rcl_get_zero_initialized_subscription();
 
-            QualityOfServiceProfile qos = new QualityOfServiceProfile();
-            IntPtr subscriptionOptions = NativeRclInterface.rclcs_subscription_create_options(qos.handle);
+            using (QualityOfServiceProfile qos = new QualityOfServiceProfile())
+            {
+                IntPtr subscriptionOptions = NativeRclInterface.rclcs_subscription_create_options(qos.handle);
+                Assert.That(subscriptionOptions, Is.Not.EqualTo(IntPtr.Zero));
 
-            MessageInternals msg = new std_msgs.msg.Bool();
-            IntPtr typeSupportHandle = msg.TypeSupportHandle;
-            NativeRcl.rcl_subscription_init(
-                ref subscription, ref node, typeSupportHandle, "/subscriber_test_topic", subscriptionOptions);
+                MessageInternals msg = new std_msgs.msg.Bool();
+                IntPtr typeSupportHandle = msg.TypeSupportHandle;
+                NativeRcl.rcl_subscription_init(
+                    ref subscription, ref node, typeSupportHandle, "/subscriber_test_topic", subscriptionOptions);
 
-            Assert.That(NativeRcl.rcl_subscription_is_valid(ref subscription), Is.True);
+                Assert.That(NativeRcl.rcl_subscription_is_valid(ref subscription), Is.True);
 
-            NativeRcl.rcl_subscription_fini(ref subscription, ref node);
-            NativeRclInterface.rclcs_subscription_dispose_options(subscriptionOptions);
+                NativeRcl.rcl_subscription_fini(ref subscription, ref node);
+                NativeRclInterface.rclcs_subscription_dispose_options(subscriptionOptions);
+            }
         }
     }
 
@@ -573,7 +614,7 @@ namespace ROS2.TestNativeMethods
         public void SetUp()
         {
             RCLInitialize.InitRcl(ref context);
-            NodeInitialize.InitNode(ref node, nodeOptions, ref context);
+            NodeInitialize.InitNode(ref node, ref nodeOptions, ref context);
         }
 
         [TearDown]

--- a/src/ros2cs/ros2cs_tests/src/NodeTest.cs
+++ b/src/ros2cs/ros2cs_tests/src/NodeTest.cs
@@ -16,6 +16,7 @@
 
 // Modifications by Jianbin Liu:
 // - Added coverage for disposed node create-entity behavior.
+// - Added node-owned entity disposal and stale-node pruning coverage.
 
 using System;
 using System.Reflection;
@@ -77,6 +78,16 @@ namespace ROS2.Test
             node.Dispose();
 
             Assert.Throws<ObjectDisposedException>(() => node.CreatePublisher<std_msgs.msg.Bool>("test_topic"));
+        }
+
+        [Test]
+        public void DirectDisposeAllowsSameNameNodeRecreate()
+        {
+            node.Dispose();
+
+            node = Ros2cs.CreateNode(TEST_NODE);
+
+            Assert.That(node.Name, Is.EqualTo(TEST_NODE));
         }
 
         [Test]
@@ -146,11 +157,62 @@ namespace ROS2.Test
         }
 
         [Test]
+        public void NodeDisposeDisposesOwnedEntities()
+        {
+            var publisher = node.CreatePublisher<std_msgs.msg.Bool>("owned_publisher");
+            var subscription = node.CreateSubscription<std_msgs.msg.Bool>("owned_subscription", msg => { });
+            var service = node.CreateService<AddTwoInts_Request, AddTwoInts_Response>(
+                "owned_service",
+                request => new AddTwoInts_Response());
+            var client = node.CreateClient<AddTwoInts_Request, AddTwoInts_Response>("owned_service");
+
+            node.Dispose();
+
+            Assert.That(publisher.IsDisposed, Is.True);
+            Assert.That(subscription.IsDisposed, Is.True);
+            Assert.That(service.IsDisposed, Is.True);
+            Assert.That(client.IsDisposed, Is.True);
+        }
+
+        [Test]
+        public void PublisherHeldAfterNodeDisposeReturnsSafely()
+        {
+            var publisher = node.CreatePublisher<std_msgs.msg.Bool>("held_publisher");
+            using var msg = new std_msgs.msg.Bool();
+
+            node.Dispose();
+
+            Assert.That(publisher.IsDisposed, Is.True);
+            Assert.DoesNotThrow(() => publisher.Publish(msg));
+        }
+
+        [Test]
         public void NodeDisposedFlagIsVolatileForChildDisposeVisibility()
         {
             FieldInfo field = typeof(Node).GetField("disposed", BindingFlags.Instance | BindingFlags.NonPublic);
             Assert.That(field, Is.Not.Null);
             Assert.That(field.GetRequiredCustomModifiers(), Does.Contain(typeof(System.Runtime.CompilerServices.IsVolatile)));
+        }
+
+        [Test]
+        public void ChildDisposedFlagsAreVolatileForEntityVisibility()
+        {
+            Type[] childTypes = {
+                typeof(Publisher<std_msgs.msg.Bool>),
+                typeof(Subscription<std_msgs.msg.Bool>),
+                typeof(Service<AddTwoInts_Request, AddTwoInts_Response>),
+                typeof(Client<AddTwoInts_Request, AddTwoInts_Response>)
+            };
+
+            foreach (Type childType in childTypes)
+            {
+                FieldInfo field = childType.GetField("disposed", BindingFlags.Instance | BindingFlags.NonPublic);
+                Assert.That(field, Is.Not.Null, childType.FullName);
+                Assert.That(
+                    field.GetRequiredCustomModifiers(),
+                    Does.Contain(typeof(System.Runtime.CompilerServices.IsVolatile)),
+                    childType.FullName);
+            }
         }
     }
 }

--- a/src/ros2cs/ros2cs_tests/src/NodeTest.cs
+++ b/src/ros2cs/ros2cs_tests/src/NodeTest.cs
@@ -18,6 +18,7 @@
 // - Added coverage for disposed node create-entity behavior.
 
 using System;
+using System.Reflection;
 using NUnit.Framework;
 using example_interfaces.srv;
 
@@ -142,6 +143,14 @@ namespace ROS2.Test
             
             Assert.That(node.RemoveClient(client));
             Assert.That(client.IsDisposed);
+        }
+
+        [Test]
+        public void NodeDisposedFlagIsVolatileForChildDisposeVisibility()
+        {
+            FieldInfo field = typeof(Node).GetField("disposed", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.That(field, Is.Not.Null);
+            Assert.That(field.GetRequiredCustomModifiers(), Does.Contain(typeof(System.Runtime.CompilerServices.IsVolatile)));
         }
     }
 }

--- a/src/ros2cs/ros2cs_tests/src/NodeTest.cs
+++ b/src/ros2cs/ros2cs_tests/src/NodeTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright 2019 Dyno Robotics (by Samuel Lindgren samuel@dynorobotics.se)
 // Copyright 2019-2021 Robotec.ai
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +13,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// Modifications by Jianbin Liu:
+// - Added coverage for disposed node create-entity behavior.
 
 using System;
 using NUnit.Framework;
@@ -63,6 +67,14 @@ namespace ROS2.Test
             {
                 publisher.Publish(new std_msgs.msg.Bool());
             }
+        }
+
+        [Test]
+        public void CreatePublisherAfterDisposeThrows()
+        {
+            node.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => node.CreatePublisher<std_msgs.msg.Bool>("test_topic"));
         }
 
         [Test]

--- a/src/ros2cs/ros2cs_tests/src/NodeTest.cs
+++ b/src/ros2cs/ros2cs_tests/src/NodeTest.cs
@@ -65,7 +65,8 @@ namespace ROS2.Test
         {
             using (Publisher<std_msgs.msg.Bool> publisher = node.CreatePublisher<std_msgs.msg.Bool>("test_topic"))
             {
-                publisher.Publish(new std_msgs.msg.Bool());
+                using var msg = new std_msgs.msg.Bool();
+                publisher.Publish(msg);
             }
         }
 
@@ -88,7 +89,7 @@ namespace ROS2.Test
               "Second string to send, has to be a bit longer for the test"
             };
 
-            test_msgs.msg.UnboundedSequences msg3 = new test_msgs.msg.UnboundedSequences();
+            using var msg3 = new test_msgs.msg.UnboundedSequences();
             msg3.String_values = setStringSequence;
             publisher.Publish(msg3);
 

--- a/src/ros2cs/ros2cs_tests/src/Ros2csCommonTest.cs
+++ b/src/ros2cs/ros2cs_tests/src/Ros2csCommonTest.cs
@@ -1,0 +1,79 @@
+// Modifications Copyright (c) 2026 Jianbin Liu.
+//
+// Modifications by Jianbin Liu:
+// - Added isolated coverage for ros2cs_common primitives.
+
+using System;
+using NUnit.Framework;
+
+namespace ROS2.Test
+{
+    [TestFixture]
+    public class Ros2csCommonTest
+    {
+        [SetUp]
+        public void ResetCommonState()
+        {
+            Ros2csLogger.LogLevel = LogLevel.DEBUG;
+            GlobalVariables.SetLoaderSettings(false, "", "");
+        }
+
+        [TearDown]
+        public void ClearLoggerCallbacks()
+        {
+            foreach (LogLevel level in Enum.GetValues(typeof(LogLevel)))
+            {
+                Ros2csLogger.SetCallback(level, null);
+            }
+            GlobalVariables.SetLoaderSettings(false, "", "");
+        }
+
+        [Test]
+        public void LoggerCallbackExceptionDoesNotEscapeLogCall()
+        {
+            Ros2csLogger.SetCallback(LogLevel.INFO, _ => throw new InvalidOperationException("expected test callback failure"));
+
+            Assert.DoesNotThrow(() => Ros2csLogger.GetInstance().LogInfo("callback failure should be isolated"));
+        }
+
+        [Test]
+        public void LoaderSettingsCanBeReplacedAtomically()
+        {
+            GlobalVariables.SetLoaderSettings(true, "libdependency.dylib", "/tmp/ros2cs/");
+
+            Assert.That(GlobalVariables.preloadLibrary, Is.True);
+            Assert.That(GlobalVariables.preloadLibraryName, Is.EqualTo("libdependency.dylib"));
+            Assert.That(GlobalVariables.absolutePath, Is.EqualTo("/tmp/ros2cs/"));
+        }
+
+        [Test]
+        public void LoaderSettingsNormalizeNullStrings()
+        {
+            GlobalVariables.SetLoaderSettings(true, null, null);
+
+            Assert.That(GlobalVariables.preloadLibrary, Is.True);
+            Assert.That(GlobalVariables.preloadLibraryName, Is.EqualTo(""));
+            Assert.That(GlobalVariables.absolutePath, Is.EqualTo(""));
+        }
+
+        [Test]
+        public void BenchmarkDisposeIsIdempotent()
+        {
+            var benchmark = new Benchmark("common-test");
+
+            benchmark.Dispose();
+            benchmark.Dispose();
+
+            Assert.That(benchmark.IsDisposed, Is.True);
+        }
+
+        [Test]
+        public void UnsatisfiedLinkErrorIsCaughtByBaseException()
+        {
+            var exception = new UnsatisfiedLinkError("missing native library");
+
+            Assert.That(exception, Is.InstanceOf<UnsatisfiedLinkException>());
+            Assert.That(exception.Message, Is.EqualTo("missing native library"));
+        }
+    }
+}

--- a/src/ros2cs/ros2cs_tests/src/ServiceTest.cs
+++ b/src/ros2cs/ros2cs_tests/src/ServiceTest.cs
@@ -1,4 +1,8 @@
 // Copyright 2019-2021 Robotec.ai
+// Modifications Copyright (c) 2026 Jianbin Liu.
+//
+// Modifications by Jianbin Liu:
+// - Added coverage for service callback exceptions during direct service take.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,6 +17,8 @@
 // limitations under the License.
 
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using NUnit.Framework;
 using example_interfaces.srv;
 
@@ -29,6 +35,14 @@ namespace ROS2.Test
 
         private Func<AddTwoInts_Request, AddTwoInts_Response> OnRequest =
             msg => throw new InvalidOperationException("callback not set");
+
+        private AddTwoInts_Request CreateRequest(int a, int b)
+        {
+            var msg = new AddTwoInts_Request();
+            msg.A = a;
+            msg.B = b;
+            return msg;
+        }
 
         [SetUp]
         public void SetUp()
@@ -60,6 +74,34 @@ namespace ROS2.Test
             Service.Dispose();
             Service = Node.CreateService<AddTwoInts_Request, AddTwoInts_Response>(SERVICE_NAME, OnRequest);
             Assert.DoesNotThrow(() => { Ros2cs.SpinOnce(Node, 0.1); });
+        }
+
+        [Test]
+        public void CallbackExceptionDoesNotEscapeTakeMessage()
+        {
+            bool callbackCalled = false;
+            Service.Dispose();
+            Service = Node.CreateService<AddTwoInts_Request, AddTwoInts_Response>(
+                SERVICE_NAME,
+                msg =>
+                {
+                    callbackCalled = true;
+                    throw new InvalidOperationException("expected test callback failure");
+                });
+
+            using var client = Node.CreateClient<AddTwoInts_Request, AddTwoInts_Response>(SERVICE_NAME);
+            Task<AddTwoInts_Response> pendingResponse = client.CallAsync(CreateRequest(1, 2));
+
+            DateTime deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+            while (!callbackCalled && DateTime.UtcNow < deadline)
+            {
+                Assert.DoesNotThrow(() => Service.TakeMessage());
+                Thread.Sleep(10);
+            }
+
+            Assert.That(callbackCalled, Is.True);
+            Assert.That(pendingResponse.IsCompleted, Is.False);
+            Assert.That(client.Cancel(pendingResponse), Is.True);
         }
     }
 }

--- a/src/ros2cs/ros2cs_tests/src/SubscriptionTest.cs
+++ b/src/ros2cs/ros2cs_tests/src/SubscriptionTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright 2019 Dyno Robotics (by Samuel Lindgren samuel@dynorobotics.se)
 // Copyright 2019-2021 Robotec.ai
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,7 +14,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Modifications by Jianbin Liu:
+// - Added coverage that spin processing continues after one subscription callback throws.
+
 using NUnit.Framework;
+using System;
 using System.Collections.Generic;
 
 namespace ROS2.Test
@@ -62,6 +67,29 @@ namespace ROS2.Test
             Ros2cs.SpinOnce(node, 0.1);
 
             Assert.That(messageData, Is.EqualTo(42));
+        }
+
+        [Test]
+        public void SpinOnceContinuesAfterSubscriptionCallbackException()
+        {
+            bool secondCallbackTriggered = false;
+            node.CreateSubscription<std_msgs.msg.Int32>(
+                "subscription_test_topic",
+                msg => { throw new InvalidOperationException("expected test callback failure"); });
+            node.CreateSubscription<std_msgs.msg.Int32>(
+                "subscription_test_topic",
+                msg => { secondCallbackTriggered = true; });
+
+            std_msgs.msg.Int32 publishedMsg = new std_msgs.msg.Int32();
+            publishedMsg.Data = 42;
+            publisher.Publish(publishedMsg);
+
+            for (int i = 0; i < 10 && !secondCallbackTriggered; i++)
+            {
+                Assert.DoesNotThrow(() => { Ros2cs.SpinOnce(node, 0.1); });
+            }
+
+            Assert.That(secondCallbackTriggered, Is.True);
         }
 
         [Test]

--- a/src/ros2cs/ros2cs_tests/src/SubscriptionTest.cs
+++ b/src/ros2cs/ros2cs_tests/src/SubscriptionTest.cs
@@ -50,7 +50,8 @@ namespace ROS2.Test
         {
             bool callbackTriggered = false;
             node.CreateSubscription<std_msgs.msg.Int32>("subscription_test_topic", (msg) => { callbackTriggered = true; });
-            publisher.Publish(new std_msgs.msg.Int32());
+            using var publishedMsg = new std_msgs.msg.Int32();
+            publisher.Publish(publishedMsg);
             Ros2cs.SpinOnce(node, 0.1);
 
             Assert.That(callbackTriggered, Is.True);
@@ -61,7 +62,7 @@ namespace ROS2.Test
         {
             int messageData = 12345;
             node.CreateSubscription<std_msgs.msg.Int32>("subscription_test_topic", (msg) => { messageData = msg.Data; });
-            std_msgs.msg.Int32 published_msg = new std_msgs.msg.Int32();
+            using var published_msg = new std_msgs.msg.Int32();
             published_msg.Data = 42;
             publisher.Publish(published_msg);
             Ros2cs.SpinOnce(node, 0.1);
@@ -80,7 +81,7 @@ namespace ROS2.Test
                 "subscription_test_topic",
                 msg => { secondCallbackTriggered = true; });
 
-            std_msgs.msg.Int32 publishedMsg = new std_msgs.msg.Int32();
+            using var publishedMsg = new std_msgs.msg.Int32();
             publishedMsg.Data = 42;
             publisher.Publish(publishedMsg);
 
@@ -137,7 +138,7 @@ namespace ROS2.Test
             node.CreateSubscription<std_msgs.msg.Int32>("subscription_test_topic",
                                                         (msg) => { count += 1; });
 
-            std_msgs.msg.Int32 published_msg = new std_msgs.msg.Int32();
+            using var published_msg = new std_msgs.msg.Int32();
             published_msg.Data = 42;
 
             for (int i = 0; i < 10; i++)
@@ -157,14 +158,13 @@ namespace ROS2.Test
         public void SubscriptionQosSensorDataDepth()
         {
             int count = 0;
-            QualityOfServiceProfile qosProfile = 
-                    new QualityOfServiceProfile(QosPresetProfile.SENSOR_DATA);
+            using var qosProfile = new QualityOfServiceProfile(QosPresetProfile.SENSOR_DATA);
 
             node.CreateSubscription<std_msgs.msg.Int32>("subscription_test_topic",
                                                         (msg) => { count += 1; },
                                                         qosProfile);
 
-            std_msgs.msg.Int32 published_msg = new std_msgs.msg.Int32();
+            using var published_msg = new std_msgs.msg.Int32();
             published_msg.Data = 42;
 
             for (int i = 0; i < 6; i++)

--- a/src/ros2cs/rosidl_generator_cs/cmake/rosidl_generator_cs_generate_interfaces.cmake
+++ b/src/ros2cs/rosidl_generator_cs/cmake/rosidl_generator_cs_generate_interfaces.cmake
@@ -245,7 +245,7 @@ foreach(_generated_msg_c_ts_file ${_generated_msg_c_ts_files})
 
   set(ros2_distro "$ENV{ROS_DISTRO}")
 
-  if(ros2_distro STREQUAL "humble" OR ros2_distro STREQUAL "rolling")
+  if(${rosidl_cmake_VERSION} VERSION_GREATER 2.5.0)
     rosidl_get_typesupport_target(c_typesupport_target "${PROJECT_NAME}" "rosidl_typesupport_c")
     target_link_libraries(${_target_name} "${c_typesupport_target}")
   else()
@@ -352,7 +352,7 @@ foreach(_generated_srv_c_ts_file ${_generated_srv_c_ts_files})
 
   set(ros2_distro "$ENV{ROS_DISTRO}")
 
-  if(ros2_distro STREQUAL "humble" OR ros2_distro STREQUAL "rolling")
+  if(${rosidl_cmake_VERSION} VERSION_GREATER 2.5.0)
     rosidl_get_typesupport_target(c_typesupport_target "${PROJECT_NAME}" "rosidl_typesupport_c")
     target_link_libraries(${_target_name} "${c_typesupport_target}")
   else()

--- a/src/ros2cs/rosidl_generator_cs/cmake/rosidl_generator_cs_generate_interfaces.cmake
+++ b/src/ros2cs/rosidl_generator_cs/cmake/rosidl_generator_cs_generate_interfaces.cmake
@@ -11,6 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# Modifications Copyright (c) 2026 Jianbin Liu.
+#
+# Modifications by Jianbin Liu:
+# - Reused generated message/service struct C objects through package-local OBJECT libraries.
+# - Preserved per-message/per-service native shared libraries for compatibility while removing repeated struct compilation.
 
 find_package(rosidl_generator_c REQUIRED)
 find_package(rosidl_typesupport_c REQUIRED)
@@ -186,6 +192,8 @@ endif()
 set(_generated_msg_c_structs_target "")
 if(_generated_msg_c_files)
   set(_generated_msg_c_structs_target "${PROJECT_NAME}__cs_msg_structs")
+  # Generated C struct sources are shared by all per-message targets in this package,
+  # so compile them once as an OBJECT library and reuse the objects below.
   add_library(${_generated_msg_c_structs_target} OBJECT
     ${_generated_msg_c_files}
   )
@@ -220,6 +228,8 @@ endif()
 set(_generated_srv_c_structs_target "")
 if(_generated_srv_c_files)
   set(_generated_srv_c_structs_target "${PROJECT_NAME}__cs_srv_structs")
+  # Generated C struct sources are shared by all per-service targets in this package,
+  # so compile them once as an OBJECT library and reuse the objects below.
   add_library(${_generated_srv_c_structs_target} OBJECT
     ${_generated_srv_c_files}
   )
@@ -272,6 +282,7 @@ foreach(_generated_msg_c_ts_file ${_generated_msg_c_ts_files})
 
   add_library(${_target_name} SHARED
     "${_generated_msg_c_ts_file}"
+    # Keep one shared library per message/typesupport for compatibility; only repeated struct compilation is removed.
     $<TARGET_OBJECTS:${_generated_msg_c_structs_target}>
   )
 
@@ -375,6 +386,7 @@ foreach(_generated_srv_c_ts_file ${_generated_srv_c_ts_files})
 
   add_library(${_target_name} SHARED
     "${_generated_srv_c_ts_file}"
+    # Keep one shared library per service/typesupport for compatibility; only repeated struct compilation is removed.
     $<TARGET_OBJECTS:${_generated_srv_c_structs_target}>
   )
 

--- a/src/ros2cs/rosidl_generator_cs/cmake/rosidl_generator_cs_generate_interfaces.cmake
+++ b/src/ros2cs/rosidl_generator_cs/cmake/rosidl_generator_cs_generate_interfaces.cmake
@@ -392,14 +392,6 @@ foreach(_generated_srv_c_ts_file ${_generated_srv_c_ts_files})
 
 endforeach()
 
-message("Install targets")
-if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
-  install(TARGETS ${_target_name_lib} EXPORT ${_target_name}
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-    RUNTIME DESTINATION bin)
-endif()
-
 set(_assembly_deps_dll "")
 
 foreach(_assembly_dep ${ros2cs_common_ASSEMBLIES_DLL})
@@ -425,19 +417,7 @@ add_dependencies(${PROJECT_NAME}_assembly
 )
 
 if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
-  set(_install_assembly_dir "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}")
-  if(NOT _generated_msg_cs_files STREQUAL "")
-    list(GET _generated_msg_cs_files 0 _msg_file)
-    get_filename_component(_msg_package_dir "${_msg_file}" DIRECTORY)
-    get_filename_component(_msg_package_dir "${_msg_package_dir}" DIRECTORY)
-    install_dotnet(${PROJECT_NAME}_assembly DESTINATION "lib/dotnet")
-    ament_export_assemblies_dll("lib/dotnet/${PROJECT_NAME}_assembly.dll")
-  endif()
-
-  if(NOT _generated_srv_cs_files STREQUAL "")
-    list(GET _generated_srv_cs_files 0 _msg_file)
-    get_filename_component(_msg_package_dir "${_msg_file}" DIRECTORY)
-    get_filename_component(_msg_package_dir "${_msg_package_dir}" DIRECTORY)
+  if(_generated_msg_cs_files OR _generated_srv_cs_files)
     install_dotnet(${PROJECT_NAME}_assembly DESTINATION "lib/dotnet")
     ament_export_assemblies_dll("lib/dotnet/${PROJECT_NAME}_assembly.dll")
   endif()

--- a/src/ros2cs/rosidl_generator_cs/cmake/rosidl_generator_cs_generate_interfaces.cmake
+++ b/src/ros2cs/rosidl_generator_cs/cmake/rosidl_generator_cs_generate_interfaces.cmake
@@ -178,6 +178,79 @@ set_property(
   ${_generated_msg_cs_files} ${_generated_msg_c_files} ${_generated_msg_c_ts_files} ${_generated_srv_cs_files} ${_generated_srv_c_files} ${_generated_srv_c_ts_files}
   PROPERTY GENERATED 1)
 
+set(_extension_compile_flags "")
+if(NOT WIN32)
+  set(_extension_compile_flags "-Wall -Wextra")
+endif()
+
+set(_generated_msg_c_structs_target "")
+if(_generated_msg_c_files)
+  set(_generated_msg_c_structs_target "${PROJECT_NAME}__cs_msg_structs")
+  add_library(${_generated_msg_c_structs_target} OBJECT
+    ${_generated_msg_c_files}
+  )
+  set_target_properties(
+    ${_generated_msg_c_structs_target}
+    PROPERTIES
+    COMPILE_FLAGS             "${_extension_compile_flags}"
+    POSITION_INDEPENDENT_CODE ON
+  )
+  target_include_directories(${_generated_msg_c_structs_target}
+    PUBLIC
+    ${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_c
+    ${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_cs
+  )
+  ament_target_dependencies(${_generated_msg_c_structs_target}
+    "rosidl_generator_c"
+    "rosidl_typesupport_c"
+    "rosidl_typesupport_interface"
+  )
+  foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})
+    ament_target_dependencies(${_generated_msg_c_structs_target}
+      ${_pkg_name}
+    )
+  endforeach()
+  if(TARGET ${PROJECT_NAME}__rosidl_generator_c)
+    add_dependencies(${_generated_msg_c_structs_target}
+      ${PROJECT_NAME}__rosidl_generator_c
+    )
+  endif()
+endif()
+
+set(_generated_srv_c_structs_target "")
+if(_generated_srv_c_files)
+  set(_generated_srv_c_structs_target "${PROJECT_NAME}__cs_srv_structs")
+  add_library(${_generated_srv_c_structs_target} OBJECT
+    ${_generated_srv_c_files}
+  )
+  set_target_properties(
+    ${_generated_srv_c_structs_target}
+    PROPERTIES
+    COMPILE_FLAGS             "${_extension_compile_flags}"
+    POSITION_INDEPENDENT_CODE ON
+  )
+  target_include_directories(${_generated_srv_c_structs_target}
+    PUBLIC
+    ${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_c
+    ${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_cs
+  )
+  ament_target_dependencies(${_generated_srv_c_structs_target}
+    "rosidl_generator_c"
+    "rosidl_typesupport_c"
+    "rosidl_typesupport_interface"
+  )
+  foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})
+    ament_target_dependencies(${_generated_srv_c_structs_target}
+      ${_pkg_name}
+    )
+  endforeach()
+  if(TARGET ${PROJECT_NAME}__rosidl_generator_c)
+    add_dependencies(${_generated_srv_c_structs_target}
+      ${PROJECT_NAME}__rosidl_generator_c
+    )
+  endif()
+endif()
+
 foreach(_generated_msg_c_ts_file ${_generated_msg_c_ts_files})
   get_filename_component(_full_folder "${_generated_msg_c_ts_file}" DIRECTORY)
   get_filename_component(_package_folder "${_full_folder}" DIRECTORY)
@@ -199,14 +272,10 @@ foreach(_generated_msg_c_ts_file ${_generated_msg_c_ts_files})
 
   add_library(${_target_name} SHARED
     "${_generated_msg_c_ts_file}"
-    "${_generated_msg_c_files}"
+    $<TARGET_OBJECTS:${_generated_msg_c_structs_target}>
   )
 
   set(_destination_dir "${_output_path}/${_parent_folder}")
-  set(_extension_compile_flags "")
-  if(NOT WIN32)
-    set(_extension_compile_flags "-Wall -Wextra")
-  endif()
 
   set_target_properties(
     ${_target_name}
@@ -306,14 +375,10 @@ foreach(_generated_srv_c_ts_file ${_generated_srv_c_ts_files})
 
   add_library(${_target_name} SHARED
     "${_generated_srv_c_ts_file}"
-    "${_generated_srv_c_files}"
+    $<TARGET_OBJECTS:${_generated_srv_c_structs_target}>
   )
 
   set(_destination_dir "${_output_path}/${_parent_folder}")
-  set(_extension_compile_flags "")
-  if(NOT WIN32)
-    set(_extension_compile_flags "-Wall -Wextra")
-  endif()
 
   set_target_properties(
     ${_target_name}

--- a/src/ros2cs/rosidl_generator_cs/cmake/rosidl_generator_cs_generate_interfaces.cmake
+++ b/src/ros2cs/rosidl_generator_cs/cmake/rosidl_generator_cs_generate_interfaces.cmake
@@ -17,6 +17,7 @@
 # Modifications by Jianbin Liu:
 # - Reused generated message/service struct C objects through package-local OBJECT libraries.
 # - Preserved per-message/per-service native shared libraries for compatibility while removing repeated struct compilation.
+# - Shortened generated CMake logical target names while preserving runtime native library names.
 
 find_package(rosidl_generator_c REQUIRED)
 find_package(rosidl_typesupport_c REQUIRED)
@@ -276,7 +277,10 @@ foreach(_generated_msg_c_ts_file ${_generated_msg_c_ts_files})
 
   find_package(${_typesupport_impl} REQUIRED)
 
-  set(_target_name "${_package_name}_${_base_msg_name}__${_typesupport_impl}")
+  set(_runtime_name "${_package_name}_${_base_msg_name}__${_typesupport_impl}")
+  # Keep the runtime DLL name stable for generated C# LoadLibrary calls, but use
+  # a short logical CMake target name so MSVC object paths stay below CMake limits.
+  set(_target_name "${PROJECT_NAME}__cs_msg_ts_${_file_index}")
 
   string_camel_case_to_lower_case_underscore("${_module_name}" _header_name)
 
@@ -292,7 +296,7 @@ foreach(_generated_msg_c_ts_file ${_generated_msg_c_ts_files})
     ${_target_name}
     PROPERTIES
     COMPILE_FLAGS                           "${_extension_compile_flags}"
-    OUTPUT_NAME                             "${_target_name}_native"
+    OUTPUT_NAME                             "${_runtime_name}_native"
     RUNTIME_OUTPUT_DIRECTORY                ${_destination_dir}
     RUNTIME_OUTPUT_DIRECTORY_DEBUG          ${_destination_dir}
     RUNTIME_OUTPUT_DIRECTORY_RELEASE        ${_destination_dir}
@@ -380,7 +384,10 @@ foreach(_generated_srv_c_ts_file ${_generated_srv_c_ts_files})
 
   find_package(${_typesupport_impl} REQUIRED)
 
-  set(_target_name "${_package_name}_srv_${_base_srv_name}__${_typesupport_impl}")
+  set(_runtime_name "${_package_name}_srv_${_base_srv_name}__${_typesupport_impl}")
+  # Keep the runtime DLL name stable for generated C# LoadLibrary calls, but use
+  # a short logical CMake target name so MSVC object paths stay below CMake limits.
+  set(_target_name "${PROJECT_NAME}__cs_srv_ts_${_file_index}")
 
   string_camel_case_to_lower_case_underscore("${_module_name}" _header_name)
 
@@ -396,7 +403,7 @@ foreach(_generated_srv_c_ts_file ${_generated_srv_c_ts_files})
     ${_target_name}
     PROPERTIES
     COMPILE_FLAGS                           "${_extension_compile_flags}"
-    OUTPUT_NAME                             "${_target_name}_native"
+    OUTPUT_NAME                             "${_runtime_name}_native"
     RUNTIME_OUTPUT_DIRECTORY                ${_destination_dir}
     RUNTIME_OUTPUT_DIRECTORY_DEBUG          ${_destination_dir}
     RUNTIME_OUTPUT_DIRECTORY_RELEASE        ${_destination_dir}

--- a/src/ros2cs/rosidl_generator_cs/resource/idl.c.em
+++ b/src/ros2cs/rosidl_generator_cs/resource/idl.c.em
@@ -1,3 +1,9 @@
+@#######################################################################
+@# Modifications Copyright (c) 2026 Jianbin Liu.
+@#
+@# Modifications by Jianbin Liu:
+@#  - Audited generated C template metadata for Jazzy generator maintenance.
+@#######################################################################
 // generated from rosidl_generator_cs/resource/idl.c.em
 // with input from @(package_name):@(interface_path)
 // generated code does not contain a copyright notice

--- a/src/ros2cs/rosidl_generator_cs/resource/idl.c.em
+++ b/src/ros2cs/rosidl_generator_cs/resource/idl.c.em
@@ -14,7 +14,6 @@
 from rosidl_cmake import convert_camel_case_to_lower_case_underscore
 include_parts = [package_name] + list(interface_path.parents[0].parts) + \
     [convert_camel_case_to_lower_case_underscore(interface_path.stem)]
-include_directives = set()
 }@
 
 @#######################################################################
@@ -33,7 +32,7 @@ TEMPLATE(
 }@
 
 @[end for]@
-@# TODO (adamdbrw): Add services and actions
+@# TODO (adamdbrw): Add actions
 
 @#######################################################################
 @# Handle service

--- a/src/ros2cs/rosidl_generator_cs/resource/idl.cs.em
+++ b/src/ros2cs/rosidl_generator_cs/resource/idl.cs.em
@@ -14,12 +14,9 @@
 from rosidl_cmake import convert_camel_case_to_lower_case_underscore
 include_parts = [package_name] + list(interface_path.parents[0].parts) + \
     [convert_camel_case_to_lower_case_underscore(interface_path.stem)]
-include_directives = set()
 }@
 
-//TODO (adamdbrw): include depending on what is needed
 using System;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using ROS2;
 using ROS2.Internal;
@@ -35,7 +32,7 @@ from rosidl_parser.definition import Message
 TEMPLATE(
     'msg.cs.em',
     package_name=package_name, interface_path=interface_path,
-    message=message, include_directives=include_directives,
+    message=message,
     get_dotnet_type=get_dotnet_type, get_field_name=get_field_name,
     constant_value_to_dotnet=constant_value_to_dotnet,
     get_c_type=get_c_type, get_marshal_type=get_marshal_type,
@@ -45,7 +42,7 @@ TEMPLATE(
 }@
 
 @[end for]@
-@# TODO (adamdbrw): Add services and actions
+@# TODO (adamdbrw): Add actions
 
 @#######################################################################
 @# Handle service
@@ -59,7 +56,7 @@ from rosidl_parser.definition import Service
 TEMPLATE(
     'srv.cs.em',
     package_name=package_name, interface_path=interface_path,service=service,
-    message=service.request_message, include_directives=include_directives,
+    message=service.request_message,
     get_dotnet_type=get_dotnet_type, get_field_name=get_field_name,
     constant_value_to_dotnet=constant_value_to_dotnet,
     get_c_type=get_c_type, get_marshal_type=get_marshal_type,
@@ -72,7 +69,7 @@ TEMPLATE(
 TEMPLATE(
     'srv.cs.em',
     package_name=package_name, interface_path=interface_path,service=service,
-    message=service.response_message, include_directives=include_directives,
+    message=service.response_message,
     get_dotnet_type=get_dotnet_type, get_field_name=get_field_name,
     constant_value_to_dotnet=constant_value_to_dotnet,
     get_c_type=get_c_type, get_marshal_type=get_marshal_type,

--- a/src/ros2cs/rosidl_generator_cs/resource/idl.cs.em
+++ b/src/ros2cs/rosidl_generator_cs/resource/idl.cs.em
@@ -1,3 +1,9 @@
+@#######################################################################
+@# Modifications Copyright (c) 2026 Jianbin Liu.
+@#
+@# Modifications by Jianbin Liu:
+@#  - Audited generated C# template metadata for Jazzy generator maintenance.
+@#######################################################################
 // generated from rosidl_generator_cs/resource/idl.cs.em
 // with input from @(package_name):@(interface_path)
 // generated code does not contain a copyright notice

--- a/src/ros2cs/rosidl_generator_cs/resource/idl_typesupport.c.em
+++ b/src/ros2cs/rosidl_generator_cs/resource/idl_typesupport.c.em
@@ -14,7 +14,6 @@
 from rosidl_cmake import convert_camel_case_to_lower_case_underscore
 include_parts = [package_name] + list(interface_path.parents[0].parts) + \
     [convert_camel_case_to_lower_case_underscore(interface_path.stem)]
-include_directives = set()
 }@
 
 @#######################################################################
@@ -32,7 +31,7 @@ TEMPLATE(
 }@
 
 @[end for]@
-@# TODO (adamdbrw): Add services and actions
+@# TODO (adamdbrw): Add actions
 
 @#######################################################################
 @# Handle service

--- a/src/ros2cs/rosidl_generator_cs/resource/idl_typesupport.c.em
+++ b/src/ros2cs/rosidl_generator_cs/resource/idl_typesupport.c.em
@@ -1,3 +1,9 @@
+@#######################################################################
+@# Modifications Copyright (c) 2026 Jianbin Liu.
+@#
+@# Modifications by Jianbin Liu:
+@#  - Audited generated IDL typesupport template metadata for Jazzy generator maintenance.
+@#######################################################################
 // generated from rosidl_generator_cs/resource/idl_typesupport.c.em
 // with input from @(package_name):@(interface_path)
 // generated code does not contain a copyright notice

--- a/src/ros2cs/rosidl_generator_cs/resource/msg.c.em
+++ b/src/ros2cs/rosidl_generator_cs/resource/msg.c.em
@@ -17,6 +17,7 @@ from rosidl_parser.definition import NamespacedType
 from rosidl_parser.definition import NamedType
 from rosidl_parser.definition import AbstractGenericString
 from rosidl_parser.definition import AbstractString
+from rosidl_parser.definition import AbstractWString
 from rosidl_parser.definition import AbstractNestedType
 from rosidl_parser.definition import AbstractSequence
 from rosidl_parser.definition import Array
@@ -33,16 +34,23 @@ msg_typename = idl_structure_type_to_c_typename(message.structure.namespaced_typ
 include_path = "/".join(include_parts)
 have_not_included_string = True
 have_not_included_arrays = True
+have_not_included_wstring = True
 }@
 #include <@(include_path).h>
 #include <rosidl_runtime_c/visibility_control.h>
 @[for member in message.structure.members]@
-@[  if isinstance(member.type, AbstractGenericString) or \
-       (isinstance(member.type, AbstractNestedType) and isinstance(member.type.value_type, AbstractString)) \
+@[  if (isinstance(member.type, AbstractString) or \
+       (isinstance(member.type, AbstractNestedType) and isinstance(member.type.value_type, AbstractString))) \
        and have_not_included_string]@
 @{have_not_included_string = False}@
 #include <rosidl_runtime_c/string.h>
 #include <rosidl_runtime_c/string_functions.h>
+@[  elif (isinstance(member.type, AbstractWString) or \
+         (isinstance(member.type, AbstractNestedType) and isinstance(member.type.value_type, AbstractWString))) \
+         and have_not_included_wstring]@
+@{have_not_included_wstring = False}@
+#include <rosidl_runtime_c/u16string.h>
+#include <rosidl_runtime_c/u16string_functions.h>
 @[  elif isinstance(member.type, AbstractNestedType) and \
          isinstance(member.type.value_type, BasicType) and have_not_included_arrays]@
 @{have_not_included_arrays = False}@
@@ -75,13 +83,21 @@ ROSIDL_GENERATOR_C_EXPORT
 void @(msg_typename)_native_write_field_@(member.name)(void *message_handle, @(get_c_type(member.type)) value)
 {
   @(msg_typename) *ros_message = (@(msg_typename) *)message_handle;
-@[    if  isinstance(member.type, AbstractGenericString)]@
-  if (&ros_message->@(member.name).data)
+@[    if  isinstance(member.type, AbstractString)]@
+  if (ros_message->@(member.name).data)
   { // reinitializing string if message is being reused
     rosidl_runtime_c__String__fini(&ros_message->@(member.name));
     rosidl_runtime_c__String__init(&ros_message->@(member.name));
   }
   rosidl_runtime_c__String__assign(
+    &ros_message->@(member.name), value);
+@[    elif isinstance(member.type, AbstractWString)]@
+  if (ros_message->@(member.name).data)
+  { // reinitializing string if message is being reused
+    rosidl_runtime_c__U16String__fini(&ros_message->@(member.name));
+    rosidl_runtime_c__U16String__init(&ros_message->@(member.name));
+  }
+  rosidl_runtime_c__U16String__assign(
     &ros_message->@(member.name), value);
 @[    else]@
   ros_message->@(member.name) = value;
@@ -141,27 +157,45 @@ ROSIDL_GENERATOR_C_EXPORT
 
 
 @[for member in message.structure.members]@
-@[  if isinstance(member.type, AbstractNestedType) and isinstance(member.type.value_type, AbstractString)]@
+@[  if isinstance(member.type, AbstractNestedType) and isinstance(member.type.value_type, AbstractGenericString)]@
 ROSIDL_GENERATOR_C_EXPORT
-bool @(msg_typename)_native_write_field_@(member.name)(char *value, int index, void *message_handle)
+bool @(msg_typename)_native_write_field_@(member.name)(@(get_c_type(member.type.value_type)) value, int index, void *message_handle)
 {
   @(msg_typename) *ros_message = (@(msg_typename) *)message_handle;
 @[    if isinstance(member.type, Array)]@
   if (index >= @(member.type.size))
       return false;
-  if (&ros_message->@(member.name)[index].data)
+@[      if isinstance(member.type.value_type, AbstractString)]@
+  if (ros_message->@(member.name)[index].data)
   { // reinitializing string if message is being reused
     rosidl_runtime_c__String__fini(&ros_message->@(member.name)[index]);
     rosidl_runtime_c__String__init(&ros_message->@(member.name)[index]);
   }
   rosidl_runtime_c__String__assign(&ros_message->@(member.name)[index], value);
+@[      elif isinstance(member.type.value_type, AbstractWString)]@
+  if (ros_message->@(member.name)[index].data)
+  { // reinitializing string if message is being reused
+    rosidl_runtime_c__U16String__fini(&ros_message->@(member.name)[index]);
+    rosidl_runtime_c__U16String__init(&ros_message->@(member.name)[index]);
+  }
+  rosidl_runtime_c__U16String__assign(&ros_message->@(member.name)[index], value);
+@[      end if]@
 @[    elif isinstance(member.type, AbstractSequence)]@
-  if (&ros_message->@(member.name).data[index].data)
+@[      if isinstance(member.type.value_type, AbstractString)]@
+  if (ros_message->@(member.name).data[index].data)
   { // reinitializing string if message is being reused
     rosidl_runtime_c__String__fini(&ros_message->@(member.name).data[index]);
     rosidl_runtime_c__String__init(&ros_message->@(member.name).data[index]);
   }
   rosidl_runtime_c__String__assign(&ros_message->@(member.name).data[index], value);
+@[      elif isinstance(member.type.value_type, AbstractWString)]@
+  if (ros_message->@(member.name).data[index].data)
+  { // reinitializing string if message is being reused
+    rosidl_runtime_c__U16String__fini(&ros_message->@(member.name).data[index]);
+    rosidl_runtime_c__U16String__init(&ros_message->@(member.name).data[index]);
+  }
+  rosidl_runtime_c__U16String__assign(&ros_message->@(member.name).data[index], value);
+@[      end if]@
 @[    end if]@
   return true;
 }
@@ -169,9 +203,9 @@ bool @(msg_typename)_native_write_field_@(member.name)(char *value, int index, v
 @[end for]@
 
 @[for member in message.structure.members]@
-@[  if isinstance(member.type, AbstractNestedType) and isinstance(member.type.value_type, AbstractString)]@
+@[  if isinstance(member.type, AbstractNestedType) and isinstance(member.type.value_type, AbstractGenericString)]@
 ROSIDL_GENERATOR_C_EXPORT
-char *@(msg_typename)_native_read_field_@(member.name)(int index, void *message_handle)
+@(get_c_type(member.type.value_type)) @(msg_typename)_native_read_field_@(member.name)(int index, void *message_handle)
 {
   @(msg_typename) *ros_message = (@(msg_typename) *)message_handle;
 @[    if isinstance(member.type, Array)]@
@@ -199,7 +233,7 @@ void * @(msg_typename)_native_get_nested_message_handle_@(member.name)(void *mes
 @[end for]@
 
 @[for member in message.structure.members]@
-@[  if isinstance(member.type, AbstractNestedType) and isinstance(member.type.value_type, (NamedType, NamespacedType, AbstractString))]@
+@[  if isinstance(member.type, AbstractNestedType) and isinstance(member.type.value_type, (NamedType, NamespacedType, AbstractGenericString))]@
 @{
 n_type = get_c_type(member.type.value_type.name) if isinstance(member.type.value_type, (NamedType)) else idl_structure_type_to_c_typename(member.type.value_type) if isinstance(member.type.value_type, NamespacedType) else idl_type_to_c(member.type.value_type)
 }

--- a/src/ros2cs/rosidl_generator_cs/resource/msg.c.em
+++ b/src/ros2cs/rosidl_generator_cs/resource/msg.c.em
@@ -1,4 +1,10 @@
 @#######################################################################
+@# Modifications Copyright (c) 2026 Jianbin Liu.
+@#
+@# Modifications by Jianbin Liu:
+@#  - Audited generated message struct C template metadata for Jazzy generator maintenance.
+@#######################################################################
+@#######################################################################
 @# EmPy template for generating <msg>_s.c files
 @#
 @# Context:

--- a/src/ros2cs/rosidl_generator_cs/resource/msg.cs.em
+++ b/src/ros2cs/rosidl_generator_cs/resource/msg.cs.em
@@ -1,4 +1,10 @@
 @#######################################################################
+@# Modifications Copyright (c) 2026 Jianbin Liu.
+@#
+@# Modifications by Jianbin Liu:
+@#  - Added unmanaged function pointer annotations for generated delegates.
+@#  - Retained generated native library handles to keep delegates valid.
+@#
 @# Included from rosidl_generator_cs/resource/idl.cs.em
 @#
 @# Context:
@@ -148,6 +154,7 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
   private static NativeReadField@(get_field_name(member.type, member.name, message_class))Type native_read_field_@(member.name) = null;
   private static NativeWriteField@(get_field_name(member.type, member.name, message_class))Type native_write_field_@(member.name) = null;
 @[  elif isinstance(member.type, (NamedType, NamespacedType))]@
+  // Explicit calling convention keeps generated delegates aligned with the native C ABI.
   [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
   private delegate IntPtr NativeGetNestedHandle@(get_field_name(member.type, member.name, message_class))Type(
     IntPtr messageHandle);
@@ -157,19 +164,33 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
 @[  if isinstance(member.type, AbstractNestedType) and \
          isinstance(member.type.value_type, (NamedType, NamespacedType, AbstractString))]@
 @[    if isinstance(member.type.value_type, (NamedType, NamespacedType))]@
+  // Explicit calling convention keeps generated delegates aligned with the native C ABI.
+  [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
   private delegate IntPtr NativeGetNestedHandle@(get_field_name(member.type, member.name, message_class))Type(
     IntPtr messageHandle, int index);
   private static NativeGetNestedHandle@(get_field_name(member.type, member.name, message_class))Type native_get_nested_message_handle_@(member.name) = null;
 @[    end if]@
+  // Explicit calling convention keeps generated delegates aligned with the native C ABI.
+  [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
   private delegate int NativeGetArraySize@(get_field_name(member.type, member.name, message_class))Type(
     IntPtr messageHandle);
   private static NativeGetArraySize@(get_field_name(member.type, member.name, message_class))Type native_get_array_size_@(member.name) = null;
 
+  // Explicit calling convention keeps generated delegates aligned with the native C ABI.
+  [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
   private delegate bool NativeInitSequence@(get_field_name(member.type, member.name, message_class))Type(
     IntPtr messageHandle, int size);
   private static NativeInitSequence@(get_field_name(member.type, member.name, message_class))Type native_init_sequence_@(member.name) = null;
 @[  end if]@
 @[end for]@
+
+  // Retain native library handles so delegates remain valid for the message type lifetime.
+  private static NativeLibraryHandle message_library_typesupport = null;
+  private static NativeLibraryHandle message_library_generator = null;
+  private static NativeLibraryHandle message_library_intro = null;
+  private static NativeLibraryHandle native_library = null;
+  private static NativeLibraryHandle message_library_typesupport_fastrtps_cpp = null;
+  private static NativeLibraryHandle message_library_typesupport_fastrtps_c = null;
 
   // This is done to preload before ros2 rmw_implementation attempts to find custom message library (and fails without absolute path)
   static private void MessageTypeSupportPreload()
@@ -203,8 +224,9 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
         { // TODO - get rcl level constants, e.g. rosidl_typesupport_fastrtps_c__identifier
           // Load typesupport for fastrtps (_c depends on _cpp)
           var loadUtils = DllLoadUtilsFactory.GetDllLoadUtils();
-          IntPtr messageLibraryTypesupportFastRTPS_CPP = loadUtils.LoadLibraryNoSuffix("@(package_name)__rosidl_typesupport_fastrtps_cpp");
-          IntPtr messageLibraryTypesupportFastRTPS_C = loadUtils.LoadLibraryNoSuffix("@(package_name)__rosidl_typesupport_fastrtps_c");
+          // Keep FastRTPS dependencies loaded after preloading succeeds.
+          message_library_typesupport_fastrtps_cpp = NativeLibraryHandle.LoadLibraryNoSuffix(loadUtils, "@(package_name)__rosidl_typesupport_fastrtps_cpp");
+          message_library_typesupport_fastrtps_c = NativeLibraryHandle.LoadLibraryNoSuffix(loadUtils, "@(package_name)__rosidl_typesupport_fastrtps_c");
       }
     }
   }
@@ -212,12 +234,14 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
   static @(message_class)()
   {
     dllLoadUtils = DllLoadUtilsFactory.GetDllLoadUtils();
-    IntPtr messageLibraryTypesupport = dllLoadUtils.LoadLibraryNoSuffix("@(package_name)__rosidl_typesupport_c");
-    IntPtr messageLibraryGenerator = dllLoadUtils.LoadLibraryNoSuffix("@(package_name)__rosidl_generator_c");
-    IntPtr messageLibraryIntro = dllLoadUtils.LoadLibraryNoSuffix("@(package_name)__rosidl_typesupport_introspection_c");
+    message_library_typesupport = NativeLibraryHandle.LoadLibraryNoSuffix(dllLoadUtils, "@(package_name)__rosidl_typesupport_c");
+    message_library_generator = NativeLibraryHandle.LoadLibraryNoSuffix(dllLoadUtils, "@(package_name)__rosidl_generator_c");
+    message_library_intro = NativeLibraryHandle.LoadLibraryNoSuffix(dllLoadUtils, "@(package_name)__rosidl_typesupport_introspection_c");
     MessageTypeSupportPreload();
 
-    IntPtr nativelibrary = dllLoadUtils.LoadLibrary("@(package_name)_@(message_class_lower)__rosidl_typesupport_c");
+    // Keep the generated native typesupport library loaded while delegates point into it.
+    native_library = NativeLibraryHandle.LoadLibrary(dllLoadUtils, "@(package_name)_@(message_class_lower)__rosidl_typesupport_c");
+    IntPtr nativelibrary = native_library.Handle;
     IntPtr native_get_typesupport_ptr = dllLoadUtils.GetProcAddress(nativelibrary, "@(c_full_name)_native_get_type_support");
     @(message_class).native_get_typesupport = (NativeGetTypeSupportType)Marshal.GetDelegateForFunctionPointer(
       native_get_typesupport_ptr, typeof(NativeGetTypeSupportType));

--- a/src/ros2cs/rosidl_generator_cs/resource/msg.cs.em
+++ b/src/ros2cs/rosidl_generator_cs/resource/msg.cs.em
@@ -51,9 +51,10 @@ namespace @(ns)
 public class @(message_class) : @(internals_interface), @(parent_interface)
 {
   private IntPtr _handle;
+  private readonly object mutex = new object();
   private static readonly DllLoadUtils dllLoadUtils;
 
-  public bool IsDisposed { get { return disposed; } }
+  public bool IsDisposed { get { lock (mutex) { return disposed; } } }
   private bool disposed;
 
   // constant declarations
@@ -119,7 +120,7 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
 
   [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
   private delegate void NativeWriteField@(get_field_name(member.type, member.name, message_class))Type(
-    IntPtr messageHandle, [MarshalAs (UnmanagedType.LPStr)] string value);
+    IntPtr messageHandle, [MarshalAs (UnmanagedType.@(get_marshal_type(member.type)))] string value);
 
 @[  elif isinstance(member.type, AbstractNestedType)]@
 @[    if isinstance(member.type.value_type, BasicType)]@
@@ -145,12 +146,23 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
       [MarshalAs (UnmanagedType.LPStr)] string value,
       int index,
       IntPtr messageHandle);
+@[    elif isinstance(member.type.value_type, AbstractWString)]@
+  [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+  internal delegate IntPtr NativeReadField@(get_field_name(member.type, member.name, message_class))Type(
+    int index,
+    IntPtr messageHandle);
+
+  [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+  internal delegate bool NativeWriteField@(get_field_name(member.type, member.name, message_class))Type(
+      [MarshalAs (UnmanagedType.LPWStr)] string value,
+      int index,
+      IntPtr messageHandle);
 
 @[    end if]@
 @[  end if]@
 
 @[  if isinstance(member.type, (AbstractGenericString, BasicType)) or \
-       (isinstance(member.type, AbstractNestedType) and isinstance(member.type.value_type, (BasicType, AbstractString)))]@
+       (isinstance(member.type, AbstractNestedType) and isinstance(member.type.value_type, (BasicType, AbstractGenericString)))]@
   private static NativeReadField@(get_field_name(member.type, member.name, message_class))Type native_read_field_@(member.name) = null;
   private static NativeWriteField@(get_field_name(member.type, member.name, message_class))Type native_write_field_@(member.name) = null;
 @[  elif isinstance(member.type, (NamedType, NamespacedType))]@
@@ -162,7 +174,7 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
 @[  end if]@
 @
 @[  if isinstance(member.type, AbstractNestedType) and \
-         isinstance(member.type.value_type, (NamedType, NamespacedType, AbstractString))]@
+         isinstance(member.type.value_type, (NamedType, NamespacedType, AbstractGenericString))]@
 @[    if isinstance(member.type.value_type, (NamedType, NamespacedType))]@
   // Explicit calling convention keeps generated delegates aligned with the native C ABI.
   [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -209,14 +221,9 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
     { //only affects Linux since on Windows PATH can be set effectively, dynamically
         const string rmw_fastrtps = "rmw_fastrtps_cpp";
         var rmw_implementation = Environment.GetEnvironmentVariable("RMW_IMPLEMENTATION");
-        if (rmw_implementation == null)
+        if (global::System.String.IsNullOrEmpty(rmw_implementation))
         {
-          var ros_distro = Environment.GetEnvironmentVariable("ROS_DISTRO");
-          if (ros_distro == "galactic")
-          { // no preloads for CycloneDDS, default for galactic
-            return;
-          }
-          rmw_implementation = rmw_fastrtps; // default for all other distros
+          return;
         }
 
         // TODO - generalize to Connext and other implementations
@@ -257,7 +264,7 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
 @[for member in message.structure.members]@
 @[  if isinstance(member.type, (BasicType, AbstractGenericString)) or \
        (isinstance(member.type, AbstractNestedType) and \
-        isinstance(member.type.value_type, (BasicType, AbstractString)))]@
+        isinstance(member.type.value_type, (BasicType, AbstractGenericString)))]@
     IntPtr native_read_field_@(member.name)_ptr =
       dllLoadUtils.GetProcAddress(nativelibrary, "@(c_full_name)_native_read_field_@(member.name)");
     @(message_class).native_read_field_@(member.name) =
@@ -277,7 +284,7 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
       native_get_nested_message_handle_@(member.name)_ptr, typeof(NativeGetNestedHandle@(get_field_name(member.type, member.name, message_class))Type));
 @[  end if]@
 @[  if isinstance(member.type, AbstractNestedType) and \
-       isinstance(member.type.value_type, (NamedType, NamespacedType, AbstractString))]@
+       isinstance(member.type.value_type, (NamedType, NamespacedType, AbstractGenericString))]@
 @[    if isinstance(member.type.value_type, (NamedType, NamespacedType))]@
 
     IntPtr native_get_nested_message_handle_@(member.name)_ptr =
@@ -315,9 +322,23 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
   {
     get
     {
-      if (_handle == IntPtr.Zero)
-        _handle = native_create_native_message();
-      return _handle;
+      lock (mutex)
+      {
+        if (disposed)
+        {
+          throw new ObjectDisposedException(nameof(@(message_class)));
+        }
+
+        if (_handle == IntPtr.Zero)
+        {
+          _handle = native_create_native_message();
+          if (_handle == IntPtr.Zero)
+          {
+            throw new RuntimeError("Failed to create native message for @(message_class)");
+          }
+        }
+        return _handle;
+      }
     }
   }
 
@@ -326,7 +347,7 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
 @[for member in message.structure.members]@
 @[  if isinstance(member.type, (NamedType, NamespacedType))]@
     @(get_field_name(member.type, member.name, message_class)) = new @(get_dotnet_type(member.type))();
-@[  elif isinstance(member.type, AbstractString)]@
+@[  elif isinstance(member.type, AbstractGenericString)]@
     @(get_field_name(member.type, member.name, message_class)) = "";
 @[  elif isinstance(member.type, AbstractSequence)]@
     @(get_field_name(member.type, member.name, message_class)) = new @(get_dotnet_type(member.type.value_type))[0];
@@ -355,6 +376,11 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
       IntPtr pStr = native_read_field_@(member.name)(handle);
       @(get_field_name(member.type, member.name, message_class)) = Marshal.PtrToStringAnsi(pStr);
     }
+@[  elif isinstance(member.type, AbstractWString)]@
+    {
+      IntPtr pStr = native_read_field_@(member.name)(handle);
+      @(get_field_name(member.type, member.name, message_class)) = Marshal.PtrToStringUni(pStr);
+    }
 @[  elif isinstance(member.type, AbstractNestedType) and isinstance(member.type.value_type, BasicType)]@
     { //TODO - (adam) this is a bit clunky. Is there a better way to marshal unsigned and bool types?
       int arraySize = 0;
@@ -378,7 +404,7 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
       }
     }
 @[  elif isinstance(member.type, AbstractNestedType) and \
-         isinstance(member.type.value_type, (NamedType, NamespacedType, AbstractString))]@
+         isinstance(member.type.value_type, (NamedType, NamespacedType, AbstractGenericString))]@
     {
       int __native_array_size = native_get_array_size_@(member.name)(handle);
       @(get_field_name(member.type, member.name, message_class)) = new @(get_dotnet_type(member.type.value_type))[__native_array_size];
@@ -389,6 +415,8 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
         @(get_field_name(member.type, member.name, message_class))[i].ReadNativeMessage(native_get_nested_message_handle_@(member.name)(handle, i));
 @[    elif isinstance(member.type.value_type, AbstractString)]@
         @(get_field_name(member.type, member.name, message_class))[i] = Marshal.PtrToStringAnsi(native_read_field_@(member.name)(i, handle));
+@[    elif isinstance(member.type.value_type, AbstractWString)]@
+        @(get_field_name(member.type, member.name, message_class))[i] = Marshal.PtrToStringUni(native_read_field_@(member.name)(i, handle));
 @[    end if]@
       }
     }
@@ -398,12 +426,6 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
 
   public void WriteNativeMessage()
   {
-    if (_handle == IntPtr.Zero)
-    { // message object reused for subsequent publishing.
-      // This could be problematic if sequences sizes changed, but me handle that by checking for it in the c implementation
-      _handle = native_create_native_message();
-    }
-
     WriteNativeMessage(Handle);
   }
 
@@ -432,7 +454,7 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
         throw new System.InvalidOperationException("Error writing field for @(member.name)");
     }
 @[  elif isinstance(member.type, AbstractNestedType) and \
-         isinstance(member.type.value_type, (NamedType, NamespacedType, AbstractString))]@
+         isinstance(member.type.value_type, (NamedType, NamespacedType, AbstractGenericString))]@
     {
       bool success = native_init_sequence_@(member.name)(handle, @(get_field_name(member.type, member.name, message_class)).Length);
       if (!success)
@@ -444,6 +466,8 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
         @(get_field_name(member.type, member.name, message_class))[i].WriteNativeMessage(innerHandle);
 @[    elif isinstance(member.type.value_type, AbstractString)]@
         native_write_field_@(member.name)(@(get_field_name(member.type, member.name, message_class))[i], i, handle);
+@[    elif isinstance(member.type.value_type, AbstractWString)]@
+        native_write_field_@(member.name)(@(get_field_name(member.type, member.name, message_class))[i], i, handle);
 @[    end if]@
       }
     }
@@ -453,20 +477,31 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
 
   public void Dispose()
   {
-    if (!disposed)
+    Dispose(true);
+    GC.SuppressFinalize(this);
+  }
+
+  private void Dispose(bool disposing)
+  {
+    lock (mutex)
     {
+      if (disposed)
+      {
+        return;
+      }
+
       if (_handle != IntPtr.Zero)
       {
         native_destroy_native_message(_handle);
         _handle = IntPtr.Zero;
-        disposed = true;
       }
+      disposed = true;
     }
   }
 
   ~@(message_class)()
   {
-    Dispose();
+    Dispose(false);
   }
 
 };  // class @(message_class)

--- a/src/ros2cs/rosidl_generator_cs/resource/msg.cs.em
+++ b/src/ros2cs/rosidl_generator_cs/resource/msg.cs.em
@@ -4,6 +4,7 @@
 @# Modifications by Jianbin Liu:
 @#  - Added unmanaged function pointer annotations for generated delegates.
 @#  - Retained generated native library handles to keep delegates valid.
+@#  - Removed generated finalizers that called native message destroy functions during runtime teardown.
 @#
 @# Included from rosidl_generator_cs/resource/idl.cs.em
 @#
@@ -475,13 +476,10 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
 @[end for]@
   }
 
+  // Generated messages intentionally do not use a finalizer. Unity/Mono can run
+  // finalizers during domain teardown after native plugin state is unsafe; callers
+  // must dispose owned messages explicitly.
   public void Dispose()
-  {
-    Dispose(true);
-    GC.SuppressFinalize(this);
-  }
-
-  private void Dispose(bool disposing)
   {
     lock (mutex)
     {
@@ -497,11 +495,6 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
       }
       disposed = true;
     }
-  }
-
-  ~@(message_class)()
-  {
-    Dispose(false);
   }
 
 };  // class @(message_class)

--- a/src/ros2cs/rosidl_generator_cs/resource/srv.c.em
+++ b/src/ros2cs/rosidl_generator_cs/resource/srv.c.em
@@ -17,6 +17,7 @@ from rosidl_parser.definition import NamespacedType
 from rosidl_parser.definition import NamedType
 from rosidl_parser.definition import AbstractGenericString
 from rosidl_parser.definition import AbstractString
+from rosidl_parser.definition import AbstractWString
 from rosidl_parser.definition import AbstractNestedType
 from rosidl_parser.definition import AbstractSequence
 from rosidl_parser.definition import Array
@@ -28,6 +29,7 @@ service_req = service.namespaced_type.name + "_Request"
 include_path = "/".join(include_parts)
 have_not_included_string = True
 have_not_included_arrays = True
+have_not_included_wstring = True
 }@
 
 @[if service_req == message.structure.namespaced_type.name ]@
@@ -42,12 +44,18 @@ have_not_included_arrays = True
 @[end if]@
 
 @[for member in message.structure.members]@
-@[  if isinstance(member.type, AbstractGenericString) or \
-       (isinstance(member.type, AbstractNestedType) and isinstance(member.type.value_type, AbstractString)) \
+@[  if (isinstance(member.type, AbstractString) or \
+       (isinstance(member.type, AbstractNestedType) and isinstance(member.type.value_type, AbstractString))) \
        and have_not_included_string]@
 @{have_not_included_string = False}@
 #include <rosidl_runtime_c/string.h>
 #include <rosidl_runtime_c/string_functions.h>
+@[  elif (isinstance(member.type, AbstractWString) or \
+         (isinstance(member.type, AbstractNestedType) and isinstance(member.type.value_type, AbstractWString))) \
+         and have_not_included_wstring]@
+@{have_not_included_wstring = False}@
+#include <rosidl_runtime_c/u16string.h>
+#include <rosidl_runtime_c/u16string_functions.h>
 @[  elif isinstance(member.type, AbstractNestedType) and \
          isinstance(member.type.value_type, BasicType) and have_not_included_arrays]@
 @{have_not_included_arrays = False}@
@@ -81,13 +89,21 @@ ROSIDL_GENERATOR_C_EXPORT
 void @(msg_typename)_native_write_field_@(member.name)(void *message_handle, @(get_c_type(member.type)) value)
 {
   @(msg_typename) *ros_message = (@(msg_typename) *)message_handle;
-@[    if  isinstance(member.type, AbstractGenericString)]@
-  if (&ros_message->@(member.name).data)
+@[    if  isinstance(member.type, AbstractString)]@
+  if (ros_message->@(member.name).data)
   { // reinitializing string if message is being reused
     rosidl_runtime_c__String__fini(&ros_message->@(member.name));
     rosidl_runtime_c__String__init(&ros_message->@(member.name));
   }
   rosidl_runtime_c__String__assign(
+    &ros_message->@(member.name), value);
+@[    elif isinstance(member.type, AbstractWString)]@
+  if (ros_message->@(member.name).data)
+  { // reinitializing string if message is being reused
+    rosidl_runtime_c__U16String__fini(&ros_message->@(member.name));
+    rosidl_runtime_c__U16String__init(&ros_message->@(member.name));
+  }
+  rosidl_runtime_c__U16String__assign(
     &ros_message->@(member.name), value);
 @[    else]@
   ros_message->@(member.name) = value;
@@ -144,27 +160,45 @@ ROSIDL_GENERATOR_C_EXPORT
 @[end for]@
 
 @[for member in message.structure.members]@
-@[  if isinstance(member.type, AbstractNestedType) and isinstance(member.type.value_type, AbstractString)]@
+@[  if isinstance(member.type, AbstractNestedType) and isinstance(member.type.value_type, AbstractGenericString)]@
 ROSIDL_GENERATOR_C_EXPORT
-bool @(msg_typename)_native_write_field_@(member.name)(char *value, int index, void *message_handle)
+bool @(msg_typename)_native_write_field_@(member.name)(@(get_c_type(member.type.value_type)) value, int index, void *message_handle)
 {
   @(msg_typename) *ros_message = (@(msg_typename) *)message_handle;
 @[    if isinstance(member.type, Array)]@
   if (index >= @(member.type.size))
       return false;
-  if (&ros_message->@(member.name)[index].data)
+@[      if isinstance(member.type.value_type, AbstractString)]@
+  if (ros_message->@(member.name)[index].data)
   { // reinitializing string if message is being reused
     rosidl_runtime_c__String__fini(&ros_message->@(member.name)[index]);
     rosidl_runtime_c__String__init(&ros_message->@(member.name)[index]);
   }
   rosidl_runtime_c__String__assign(&ros_message->@(member.name)[index], value);
+@[      elif isinstance(member.type.value_type, AbstractWString)]@
+  if (ros_message->@(member.name)[index].data)
+  { // reinitializing string if message is being reused
+    rosidl_runtime_c__U16String__fini(&ros_message->@(member.name)[index]);
+    rosidl_runtime_c__U16String__init(&ros_message->@(member.name)[index]);
+  }
+  rosidl_runtime_c__U16String__assign(&ros_message->@(member.name)[index], value);
+@[      end if]@
 @[    elif isinstance(member.type, AbstractSequence)]@
-  if (&ros_message->@(member.name).data[index].data)
+@[      if isinstance(member.type.value_type, AbstractString)]@
+  if (ros_message->@(member.name).data[index].data)
   { // reinitializing string if message is being reused
     rosidl_runtime_c__String__fini(&ros_message->@(member.name).data[index]);
     rosidl_runtime_c__String__init(&ros_message->@(member.name).data[index]);
   }
   rosidl_runtime_c__String__assign(&ros_message->@(member.name).data[index], value);
+@[      elif isinstance(member.type.value_type, AbstractWString)]@
+  if (ros_message->@(member.name).data[index].data)
+  { // reinitializing string if message is being reused
+    rosidl_runtime_c__U16String__fini(&ros_message->@(member.name).data[index]);
+    rosidl_runtime_c__U16String__init(&ros_message->@(member.name).data[index]);
+  }
+  rosidl_runtime_c__U16String__assign(&ros_message->@(member.name).data[index], value);
+@[      end if]@
 @[    end if]@
   return true;
 }
@@ -172,9 +206,9 @@ bool @(msg_typename)_native_write_field_@(member.name)(char *value, int index, v
 @[end for]@
 
 @[for member in message.structure.members]@
-@[  if isinstance(member.type, AbstractNestedType) and isinstance(member.type.value_type, AbstractString)]@
+@[  if isinstance(member.type, AbstractNestedType) and isinstance(member.type.value_type, AbstractGenericString)]@
 ROSIDL_GENERATOR_C_EXPORT
-char *@(msg_typename)_native_read_field_@(member.name)(int index, void *message_handle)
+@(get_c_type(member.type.value_type)) @(msg_typename)_native_read_field_@(member.name)(int index, void *message_handle)
 {
   @(msg_typename) *ros_message = (@(msg_typename) *)message_handle;
 @[    if isinstance(member.type, Array)]@
@@ -202,7 +236,7 @@ void * @(msg_typename)_native_get_nested_message_handle_@(member.name)(void *mes
 @[end for]@
 
 @[for member in message.structure.members]@
-@[  if isinstance(member.type, AbstractNestedType) and isinstance(member.type.value_type, (NamedType, NamespacedType, AbstractString))]@
+@[  if isinstance(member.type, AbstractNestedType) and isinstance(member.type.value_type, (NamedType, NamespacedType, AbstractGenericString))]@
 @{
 n_type = get_c_type(member.type.value_type.name) if isinstance(member.type.value_type, (NamedType)) else idl_structure_type_to_c_typename(member.type.value_type) if isinstance(member.type.value_type, NamespacedType) else idl_type_to_c(member.type.value_type)
 }

--- a/src/ros2cs/rosidl_generator_cs/resource/srv.c.em
+++ b/src/ros2cs/rosidl_generator_cs/resource/srv.c.em
@@ -1,4 +1,10 @@
 @#######################################################################
+@# Modifications Copyright (c) 2026 Jianbin Liu.
+@#
+@# Modifications by Jianbin Liu:
+@#  - Audited generated service struct C template metadata for Jazzy generator maintenance.
+@#######################################################################
+@#######################################################################
 @# EmPy template for generating <srv>_s.c files
 @#
 @# Context:

--- a/src/ros2cs/rosidl_generator_cs/resource/srv.cs.em
+++ b/src/ros2cs/rosidl_generator_cs/resource/srv.cs.em
@@ -54,9 +54,10 @@ namespace @(ns)
 public class @(message_class) : @(internals_interface), @(parent_interface)
 {
   private IntPtr _handle;
+  private readonly object mutex = new object();
   private static readonly DllLoadUtils dllLoadUtils;
 
-  public bool IsDisposed { get { return disposed; } }
+  public bool IsDisposed { get { lock (mutex) { return disposed; } } }
   private bool disposed;
 
   // constant declarations
@@ -122,7 +123,7 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
 
   [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
   private delegate void NativeWriteField@(get_field_name(member.type, member.name, message_class))Type(
-    IntPtr messageHandle, [MarshalAs (UnmanagedType.LPStr)] string value);
+    IntPtr messageHandle, [MarshalAs (UnmanagedType.@(get_marshal_type(member.type)))] string value);
 
 @[  elif isinstance(member.type, AbstractNestedType)]@
 @[    if isinstance(member.type.value_type, BasicType)]@
@@ -148,12 +149,23 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
       [MarshalAs (UnmanagedType.LPStr)] string value,
       int index,
       IntPtr messageHandle);
+@[    elif isinstance(member.type.value_type, AbstractWString)]@
+  [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+  internal delegate IntPtr NativeReadField@(get_field_name(member.type, member.name, message_class))Type(
+    int index,
+    IntPtr messageHandle);
+
+  [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+  internal delegate bool NativeWriteField@(get_field_name(member.type, member.name, message_class))Type(
+      [MarshalAs (UnmanagedType.LPWStr)] string value,
+      int index,
+      IntPtr messageHandle);
 
 @[    end if]@
 @[  end if]@
 
 @[  if isinstance(member.type, (AbstractGenericString, BasicType)) or \
-       (isinstance(member.type, AbstractNestedType) and isinstance(member.type.value_type, (BasicType, AbstractString)))]@
+       (isinstance(member.type, AbstractNestedType) and isinstance(member.type.value_type, (BasicType, AbstractGenericString)))]@
   private static NativeReadField@(get_field_name(member.type, member.name, message_class))Type native_read_field_@(member.name) = null;
   private static NativeWriteField@(get_field_name(member.type, member.name, message_class))Type native_write_field_@(member.name) = null;
 @[  elif isinstance(member.type, (NamedType, NamespacedType))]@
@@ -165,7 +177,7 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
 @[  end if]@
 @
 @[  if isinstance(member.type, AbstractNestedType) and \
-         isinstance(member.type.value_type, (NamedType, NamespacedType, AbstractString))]@
+         isinstance(member.type.value_type, (NamedType, NamespacedType, AbstractGenericString))]@
 @[    if isinstance(member.type.value_type, (NamedType, NamespacedType))]@
   // Explicit calling convention keeps generated delegates aligned with the native C ABI.
   [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -212,14 +224,9 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
     { //only affects Linux since on Windows PATH can be set effectively, dynamically
         const string rmw_fastrtps = "rmw_fastrtps_cpp";
         var rmw_implementation = Environment.GetEnvironmentVariable("RMW_IMPLEMENTATION");
-        if (rmw_implementation == null)
+        if (global::System.String.IsNullOrEmpty(rmw_implementation))
         {
-          var ros_distro = Environment.GetEnvironmentVariable("ROS_DISTRO");
-          if (ros_distro == "galactic")
-          { // no preloads for CycloneDDS, default for galactic
-            return;
-          }
-          rmw_implementation = rmw_fastrtps; // default for all other distros
+          return;
         }
 
         // TODO - generalize to Connext and other implementations
@@ -262,7 +269,7 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
 @[for member in message.structure.members]@
 @[  if isinstance(member.type, (BasicType, AbstractGenericString)) or \
        (isinstance(member.type, AbstractNestedType) and \
-        isinstance(member.type.value_type, (BasicType, AbstractString)))]@
+        isinstance(member.type.value_type, (BasicType, AbstractGenericString)))]@
     IntPtr native_read_field_@(member.name)_ptr =
       dllLoadUtils.GetProcAddress(nativelibrary, "@(c_full_name)_native_read_field_@(member.name)");
     @(message_class).native_read_field_@(member.name) =
@@ -282,7 +289,7 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
       native_get_nested_message_handle_@(member.name)_ptr, typeof(NativeGetNestedHandle@(get_field_name(member.type, member.name, message_class))Type));
 @[  end if]@
 @[  if isinstance(member.type, AbstractNestedType) and \
-       isinstance(member.type.value_type, (NamedType, NamespacedType, AbstractString))]@
+       isinstance(member.type.value_type, (NamedType, NamespacedType, AbstractGenericString))]@
 @[    if isinstance(member.type.value_type, (NamedType, NamespacedType))]@
 
     IntPtr native_get_nested_message_handle_@(member.name)_ptr =
@@ -320,9 +327,23 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
   {
     get
     {
-      if (_handle == IntPtr.Zero)
-        _handle = native_create_native_message();
-      return _handle;
+      lock (mutex)
+      {
+        if (disposed)
+        {
+          throw new ObjectDisposedException(nameof(@(message_class)));
+        }
+
+        if (_handle == IntPtr.Zero)
+        {
+          _handle = native_create_native_message();
+          if (_handle == IntPtr.Zero)
+          {
+            throw new RuntimeError("Failed to create native message for @(message_class)");
+          }
+        }
+        return _handle;
+      }
     }
   }
 
@@ -331,7 +352,7 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
 @[for member in message.structure.members]@
 @[  if isinstance(member.type, (NamedType, NamespacedType))]@
     @(get_field_name(member.type, member.name, message_class)) = new @(get_dotnet_type(member.type))();
-@[  elif isinstance(member.type, AbstractString)]@
+@[  elif isinstance(member.type, AbstractGenericString)]@
     @(get_field_name(member.type, member.name, message_class)) = "";
 @[  elif isinstance(member.type, AbstractSequence)]@
     @(get_field_name(member.type, member.name, message_class)) = new @(get_dotnet_type(member.type.value_type))[0];
@@ -360,15 +381,23 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
       IntPtr pStr = native_read_field_@(member.name)(handle);
       @(get_field_name(member.type, member.name, message_class)) = Marshal.PtrToStringAnsi(pStr);
     }
+@[  elif isinstance(member.type, AbstractWString)]@
+    {
+      IntPtr pStr = native_read_field_@(member.name)(handle);
+      @(get_field_name(member.type, member.name, message_class)) = Marshal.PtrToStringUni(pStr);
+    }
 @[  elif isinstance(member.type, AbstractNestedType) and isinstance(member.type.value_type, BasicType)]@
     { //TODO - (adam) this is a bit clunky. Is there a better way to marshal unsigned and bool types?
       int arraySize = 0;
       IntPtr pArr = native_read_field_@(member.name)(out arraySize, handle);
       @(get_field_name(member.type, member.name, message_class)) = new @(get_dotnet_type(member.type.value_type))[arraySize];
       @(get_marshal_array_type(member.type))[] __@(get_field_name(member.type, member.name, message_class)) = new @(get_marshal_array_type(member.type))[arraySize];
-      int start = 0;
 
-      Marshal.Copy(pArr, __@(get_field_name(member.type, member.name, message_class)), start, arraySize);
+      if (arraySize != 0)
+      {
+        int start = 0;
+        Marshal.Copy(pArr, __@(get_field_name(member.type, member.name, message_class)), start, arraySize);
+      }
       for (int i = 0; i < arraySize; ++i)
       {
 @[    if get_dotnet_type(member.type.value_type) == 'bool']@
@@ -380,7 +409,7 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
       }
     }
 @[  elif isinstance(member.type, AbstractNestedType) and \
-         isinstance(member.type.value_type, (NamedType, NamespacedType, AbstractString))]@
+         isinstance(member.type.value_type, (NamedType, NamespacedType, AbstractGenericString))]@
     {
       int __native_array_size = native_get_array_size_@(member.name)(handle);
       @(get_field_name(member.type, member.name, message_class)) = new @(get_dotnet_type(member.type.value_type))[__native_array_size];
@@ -391,6 +420,8 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
         @(get_field_name(member.type, member.name, message_class))[i].ReadNativeMessage(native_get_nested_message_handle_@(member.name)(handle, i));
 @[    elif isinstance(member.type.value_type, AbstractString)]@
         @(get_field_name(member.type, member.name, message_class))[i] = Marshal.PtrToStringAnsi(native_read_field_@(member.name)(i, handle));
+@[    elif isinstance(member.type.value_type, AbstractWString)]@
+        @(get_field_name(member.type, member.name, message_class))[i] = Marshal.PtrToStringUni(native_read_field_@(member.name)(i, handle));
 @[    end if]@
       }
     }
@@ -400,12 +431,6 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
 
   public void WriteNativeMessage()
   {
-    if (_handle == IntPtr.Zero)
-    { // message object reused for subsequent publishing.
-      // This could be problematic if sequences sizes changed, but me handle that by checking for it in the c implementation
-      _handle = native_create_native_message();
-    }
-
     WriteNativeMessage(Handle);
   }
 
@@ -434,7 +459,7 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
         throw new System.InvalidOperationException("Error writing field for @(member.name)");
     }
 @[  elif isinstance(member.type, AbstractNestedType) and \
-         isinstance(member.type.value_type, (NamedType, NamespacedType, AbstractString))]@
+         isinstance(member.type.value_type, (NamedType, NamespacedType, AbstractGenericString))]@
     {
       bool success = native_init_sequence_@(member.name)(handle, @(get_field_name(member.type, member.name, message_class)).Length);
       if (!success)
@@ -446,6 +471,8 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
         @(get_field_name(member.type, member.name, message_class))[i].WriteNativeMessage(innerHandle);
 @[    elif isinstance(member.type.value_type, AbstractString)]@
         native_write_field_@(member.name)(@(get_field_name(member.type, member.name, message_class))[i], i, handle);
+@[    elif isinstance(member.type.value_type, AbstractWString)]@
+        native_write_field_@(member.name)(@(get_field_name(member.type, member.name, message_class))[i], i, handle);
 @[    end if]@
       }
     }
@@ -455,20 +482,31 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
 
   public void Dispose()
   {
-    if (!disposed)
+    Dispose(true);
+    GC.SuppressFinalize(this);
+  }
+
+  private void Dispose(bool disposing)
+  {
+    lock (mutex)
     {
+      if (disposed)
+      {
+        return;
+      }
+
       if (_handle != IntPtr.Zero)
       {
         native_destroy_native_message(_handle);
         _handle = IntPtr.Zero;
-        disposed = true;
       }
+      disposed = true;
     }
   }
 
   ~@(message_class)()
   {
-    Dispose();
+    Dispose(false);
   }
 
 };  // class @(message_class)

--- a/src/ros2cs/rosidl_generator_cs/resource/srv.cs.em
+++ b/src/ros2cs/rosidl_generator_cs/resource/srv.cs.em
@@ -4,6 +4,7 @@
 @# Modifications by Jianbin Liu:
 @#  - Added unmanaged function pointer annotations for generated delegates.
 @#  - Retained generated native library handles to keep delegates valid.
+@#  - Removed generated finalizers that called native message destroy functions during runtime teardown.
 @#
 @# Included from rosidl_generator_cs/resource/idl.cs.em
 @#
@@ -480,13 +481,10 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
 @[end for]@
   }
 
+  // Generated service messages intentionally do not use a finalizer. Unity/Mono can
+  // run finalizers during domain teardown after native plugin state is unsafe; callers
+  // must dispose owned messages explicitly.
   public void Dispose()
-  {
-    Dispose(true);
-    GC.SuppressFinalize(this);
-  }
-
-  private void Dispose(bool disposing)
   {
     lock (mutex)
     {
@@ -502,11 +500,6 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
       }
       disposed = true;
     }
-  }
-
-  ~@(message_class)()
-  {
-    Dispose(false);
   }
 
 };  // class @(message_class)

--- a/src/ros2cs/rosidl_generator_cs/resource/srv.cs.em
+++ b/src/ros2cs/rosidl_generator_cs/resource/srv.cs.em
@@ -1,4 +1,10 @@
 @#######################################################################
+@# Modifications Copyright (c) 2026 Jianbin Liu.
+@#
+@# Modifications by Jianbin Liu:
+@#  - Added unmanaged function pointer annotations for generated delegates.
+@#  - Retained generated native library handles to keep delegates valid.
+@#
 @# Included from rosidl_generator_cs/resource/idl.cs.em
 @#
 @# Context:
@@ -151,6 +157,7 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
   private static NativeReadField@(get_field_name(member.type, member.name, message_class))Type native_read_field_@(member.name) = null;
   private static NativeWriteField@(get_field_name(member.type, member.name, message_class))Type native_write_field_@(member.name) = null;
 @[  elif isinstance(member.type, (NamedType, NamespacedType))]@
+  // Explicit calling convention keeps generated delegates aligned with the native C ABI.
   [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
   private delegate IntPtr NativeGetNestedHandle@(get_field_name(member.type, member.name, message_class))Type(
     IntPtr messageHandle);
@@ -160,19 +167,33 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
 @[  if isinstance(member.type, AbstractNestedType) and \
          isinstance(member.type.value_type, (NamedType, NamespacedType, AbstractString))]@
 @[    if isinstance(member.type.value_type, (NamedType, NamespacedType))]@
+  // Explicit calling convention keeps generated delegates aligned with the native C ABI.
+  [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
   private delegate IntPtr NativeGetNestedHandle@(get_field_name(member.type, member.name, message_class))Type(
     IntPtr messageHandle, int index);
   private static NativeGetNestedHandle@(get_field_name(member.type, member.name, message_class))Type native_get_nested_message_handle_@(member.name) = null;
 @[    end if]@
+  // Explicit calling convention keeps generated delegates aligned with the native C ABI.
+  [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
   private delegate int NativeGetArraySize@(get_field_name(member.type, member.name, message_class))Type(
     IntPtr messageHandle);
   private static NativeGetArraySize@(get_field_name(member.type, member.name, message_class))Type native_get_array_size_@(member.name) = null;
 
+  // Explicit calling convention keeps generated delegates aligned with the native C ABI.
+  [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
   private delegate bool NativeInitSequence@(get_field_name(member.type, member.name, message_class))Type(
     IntPtr messageHandle, int size);
   private static NativeInitSequence@(get_field_name(member.type, member.name, message_class))Type native_init_sequence_@(member.name) = null;
 @[  end if]@
 @[end for]@
+
+  // Retain native library handles so delegates remain valid for the service message type lifetime.
+  private static NativeLibraryHandle message_library_typesupport = null;
+  private static NativeLibraryHandle message_library_generator = null;
+  private static NativeLibraryHandle message_library_intro = null;
+  private static NativeLibraryHandle native_library = null;
+  private static NativeLibraryHandle message_library_typesupport_fastrtps_cpp = null;
+  private static NativeLibraryHandle message_library_typesupport_fastrtps_c = null;
 
   // This is done to preload before ros2 rmw_implementation attempts to find custom message library (and fails without absolute path)
   static private void MessageTypeSupportPreload()
@@ -206,8 +227,9 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
         { // TODO - get rcl level constants, e.g. rosidl_typesupport_fastrtps_c__identifier
           // Load typesupport for fastrtps (_c depends on _cpp)
           var loadUtils = DllLoadUtilsFactory.GetDllLoadUtils();
-          IntPtr messageLibraryTypesupportFastRTPS_CPP = loadUtils.LoadLibraryNoSuffix("@(package_name)__rosidl_typesupport_fastrtps_cpp");
-          IntPtr messageLibraryTypesupportFastRTPS_C = loadUtils.LoadLibraryNoSuffix("@(package_name)__rosidl_typesupport_fastrtps_c");
+          // Keep FastRTPS dependencies loaded after preloading succeeds.
+          message_library_typesupport_fastrtps_cpp = NativeLibraryHandle.LoadLibraryNoSuffix(loadUtils, "@(package_name)__rosidl_typesupport_fastrtps_cpp");
+          message_library_typesupport_fastrtps_c = NativeLibraryHandle.LoadLibraryNoSuffix(loadUtils, "@(package_name)__rosidl_typesupport_fastrtps_c");
       }
     }
   }
@@ -217,12 +239,14 @@ public class @(message_class) : @(internals_interface), @(parent_interface)
     Ros2csLogger logger = Ros2csLogger.GetInstance();
 
     dllLoadUtils = DllLoadUtilsFactory.GetDllLoadUtils();
-    IntPtr messageLibraryTypesupport = dllLoadUtils.LoadLibraryNoSuffix("@(package_name)__rosidl_typesupport_c");
-    IntPtr messageLibraryGenerator = dllLoadUtils.LoadLibraryNoSuffix("@(package_name)__rosidl_generator_c");
-    IntPtr messageLibraryIntro = dllLoadUtils.LoadLibraryNoSuffix("@(package_name)__rosidl_typesupport_introspection_c");
+    message_library_typesupport = NativeLibraryHandle.LoadLibraryNoSuffix(dllLoadUtils, "@(package_name)__rosidl_typesupport_c");
+    message_library_generator = NativeLibraryHandle.LoadLibraryNoSuffix(dllLoadUtils, "@(package_name)__rosidl_generator_c");
+    message_library_intro = NativeLibraryHandle.LoadLibraryNoSuffix(dllLoadUtils, "@(package_name)__rosidl_typesupport_introspection_c");
     MessageTypeSupportPreload();
 
-    IntPtr nativelibrary = dllLoadUtils.LoadLibrary("@(package_name)_srv_@(service_class_lower)__rosidl_typesupport_c");
+    // Keep the generated native typesupport library loaded while delegates point into it.
+    native_library = NativeLibraryHandle.LoadLibrary(dllLoadUtils, "@(package_name)_srv_@(service_class_lower)__rosidl_typesupport_c");
+    IntPtr nativelibrary = native_library.Handle;
     IntPtr native_get_typesupport_ptr = dllLoadUtils.GetProcAddress(nativelibrary, "@(c_full_name)_native_get_type_support");
     @(message_class).native_get_typesupport = (NativeGetTypeSupportType)Marshal.GetDelegateForFunctionPointer(
       native_get_typesupport_ptr, typeof(NativeGetTypeSupportType));

--- a/src/ros2cs/rosidl_generator_cs/rosidl_generator_cs/generate_cs_impl.py
+++ b/src/ros2cs/rosidl_generator_cs/rosidl_generator_cs/generate_cs_impl.py
@@ -21,6 +21,7 @@ from rosidl_generator_c import idl_type_to_c
 from rosidl_parser.definition import AbstractGenericString
 from rosidl_parser.definition import AbstractSequence
 from rosidl_parser.definition import AbstractString
+from rosidl_parser.definition import AbstractWString
 from rosidl_parser.definition import Array
 from rosidl_parser.definition import BasicType
 from rosidl_parser.definition import NamespacedType
@@ -76,6 +77,8 @@ def constant_value_to_dotnet(type_, value):
 
 
 def get_c_type(type_):
+    if isinstance(type_, AbstractWString):
+        return 'const uint16_t *'
     if isinstance(type_, AbstractGenericString):
         return 'const char *'
     return idl_type_to_c(type_)
@@ -103,6 +106,8 @@ BASIC_IDL_TYPES_TO_MARSHAL = {
 def get_marshal_type(type_):
     if isinstance(type_, BasicType):
         return BASIC_IDL_TYPES_TO_MARSHAL[type_.typename]
+    if isinstance(type_, AbstractWString):
+        return 'LPWStr'
     if isinstance(type_, AbstractString):
         return 'LPStr'
     assert False, "unsupported marshal type '%s'" % type_

--- a/src/ros2cs/rosidl_generator_cs/rosidl_generator_cs/generate_cs_impl.py
+++ b/src/ros2cs/rosidl_generator_cs/rosidl_generator_cs/generate_cs_impl.py
@@ -1,4 +1,5 @@
 # Copyright 2019-2021 Robotec.ai
+# Modifications Copyright (c) 2026 Jianbin Liu.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# Modifications by Jianbin Liu:
+# - Fixed int8 sequence marshaling to use a byte-compatible native representation.
 
 from rosidl_cmake import generate_files
 from rosidl_generator_c import idl_type_to_c
@@ -113,7 +117,8 @@ BASIC_IDL_TYPES_TO_MARSHAL_ARRAY = {
     'boolean': 'byte',
     'octet': 'byte',
     'uint8': 'byte',
-    'int8': 'char',
+    # int8 sequences are copied through unmanaged bytes so signed values survive native roundtrips.
+    'int8': 'byte',
     'uint16': 'short',
     'int16': 'short',
     'uint32': 'int',

--- a/test.ps1
+++ b/test.ps1
@@ -1,6 +1,16 @@
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
+if ([string]::IsNullOrEmpty($Env:ROS_DISTRO)) {
+    Write-Host "Source your ros2 distro first." -ForegroundColor Red
+    exit 1
+}
+
+if (-not (Get-Command colcon -ErrorAction SilentlyContinue)) {
+    Write-Host "Can't find colcon. Source your ROS 2 environment or install colcon first." -ForegroundColor Red
+    exit 1
+}
+
 colcon test --merge-install --packages-select ros2cs_tests
 $testExitCode = $LASTEXITCODE
 

--- a/test.ps1
+++ b/test.ps1
@@ -1,1 +1,14 @@
-colcon test --merge-install --packages-select ros2cs_tests; colcon test-result --verbose
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+colcon test --merge-install --packages-select ros2cs_tests
+$testExitCode = $LASTEXITCODE
+
+colcon test-result --verbose
+$resultExitCode = $LASTEXITCODE
+
+if ($testExitCode -ne 0) {
+    exit $testExitCode
+}
+
+exit $resultExitCode

--- a/test.ps1
+++ b/test.ps1
@@ -1,6 +1,11 @@
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
+# Modifications Copyright (c) 2026 Jianbin Liu.
+#
+# Modifications by Jianbin Liu:
+# - Added ROS environment checks and preserved failing test-result exit codes.
+
 if ([string]::IsNullOrEmpty($Env:ROS_DISTRO)) {
     Write-Host "Source your ros2 distro first." -ForegroundColor Red
     exit 1

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Modifications Copyright (c) 2026 Jianbin Liu.
+#
+# Modifications by Jianbin Liu:
+# - Added ROS environment checks and preserved failing test-result exit codes.
+
 set -u
 
 if [ -z "${ROS_DISTRO:-}" ]; then

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 set -u
 
+if [ -z "${ROS_DISTRO:-}" ]; then
+    echo "Source your ros2 distro first."
+    exit 1
+fi
+
+if ! command -v colcon >/dev/null 2>&1; then
+    echo "Can't find colcon. Source your ROS 2 environment or install colcon first."
+    exit 1
+fi
+
 colcon test --merge-install --packages-select ros2cs_tests
 test_exit_code=$?
 

--- a/test.sh
+++ b/test.sh
@@ -3,7 +3,9 @@
 #
 # Modifications by Jianbin Liu:
 # - Added ROS environment checks and preserved failing test-result exit codes.
+# - Documented why this script does not use set -e.
 
+# Keep -e disabled so colcon test-result still runs and prints diagnostics after colcon test fails.
 set -u
 
 if [ -z "${ROS_DISTRO:-}" ]; then

--- a/test.sh
+++ b/test.sh
@@ -1,2 +1,14 @@
-#!/bin/bash
-colcon test --merge-install --packages-select ros2cs_tests; colcon test-result --verbose
+#!/usr/bin/env bash
+set -u
+
+colcon test --merge-install --packages-select ros2cs_tests
+test_exit_code=$?
+
+colcon test-result --verbose
+result_exit_code=$?
+
+if [ "$test_exit_code" -ne 0 ]; then
+    exit "$test_exit_code"
+fi
+
+exit "$result_exit_code"


### PR DESCRIPTION
## Summary

Merges the Phase 15 ros2cs follow-up fixes across repository contract, build orchestration, common managed primitives, native interop, context lifecycle, and node/entity lifecycle.

## Changes

- Normalize supported ROS 2 repository contract docs and `.repos` maintenance targets.
- Harden root build/test orchestration scripts and repo-fetch behavior.
- Fix common managed primitives around loader settings snapshots, macOS loader parity, message disposal, and logger callback isolation.
- Tighten native interop surface with safer native handle/error plumbing and tests.
- Harden context init/shutdown, wait set, clock behavior, and lifecycle tests.
- Fix node/entity lifecycle gaps:
  - direct `node.Dispose()` no longer leaves stale same-name conflicts
  - child entity disposed flags are volatile
  - node-owned entities are covered by cascade-disposal tests
  - `Client.Call()` reentry guard is covered by tests

## Verification

- `colcon build --packages-select ros2cs_common ros2cs_core ros2cs_tests --merge-install --event-handlers console_direct+`
- `colcon test --packages-select ros2cs_tests --merge-install --event-handlers console_direct+`

Latest test result: `101` ros2cs tests passed, finalizer probe passed.